### PR TITLE
feat(agent-protocol): retry run-completion callbacks, with BullMQ owning the schedule

### DIFF
--- a/docs/langgraph-cli-compat.md
+++ b/docs/langgraph-cli-compat.md
@@ -136,6 +136,9 @@ it but is never required.
     // Retention for `Idempotency-Key` records (skein extension; see below). Tuning only —
     // omitting the block does NOT disable the header.
     "idempotency": { "retention_hours": 24, "in_flight_minutes": 15 },
+    // Delivery policy for run-completion callbacks (skein extension; see below). Tuning only —
+    // omitting the block does NOT make callbacks fire-once.
+    "webhooks": { "retries": { "max_attempts": 12 }, "allowed_hosts": ["hooks.example.com"] },
   },
 
   // .env path OR inline map
@@ -195,6 +198,7 @@ it but is never required.
 | `node_version`         | Used by `skein build` / `skein dockerfile` base image selection. Defaults to Node 24 LTS when omitted; an explicit value is honoured verbatim, including an older one.                                                                                                                                                                                                                                                                             |
 | `skein.runtime`        | Native production server and pinned official image: `node`, `bun`, or `deno`. Bun/Deno use `@skein-js/fetch` with `Bun.serve`/`Deno.serve`, never Express compatibility.                                                                                                                                                                                                                                                                           |
 | `skein.idempotency`    | Retention for `Idempotency-Key` records. Tuning only — the header is honoured either way. See [below](#idempotency-skeinidempotency).                                                                                                                                                                                                                                                                                                              |
+| `skein.webhooks`       | How run-completion callbacks are retried and bounded. Tuning only — a run carrying a `webhook` owes a callback either way. See [below](#webhooks-skeinwebhooks).                                                                                                                                                                                                                                                                                   |
 | `env`                  | Loaded into `process.env` at boot (dev) / baked into the image (build).                                                                                                                                                                                                                                                                                                                                                                            |
 | `store`                | `store.index.{embed,dims,fields,hnsw}` configures pgvector semantic search on the Postgres driver (`hnsw: true` opts into the approximate index); `store.ttl.{default_ttl,refresh_on_read,sweep_interval_minutes}` expires items. `store.adapter` is a **skein extension** — `path:export` to your own LangGraph `BaseStore` (e.g. `PostgresStore`, `MongoDBStore`), which then serves the whole `/store` surface. See [storage.md](./storage.md). |
 | `checkpointer`         | `"default"` → `PostgresSaver`; dev falls back to an in-memory `MemorySaver`.                                                                                                                                                                                                                                                                                                                                                                       |
@@ -262,6 +266,62 @@ What each one is for:
 Honoured identically on every driver combination, including `skein dev` with no Docker. See
 [agent-protocol.md](./agent-protocol.md#idempotent-run-creation-idempotency-key) for the request
 semantics and the replay table.
+
+## Webhooks (`skein.webhooks`)
+
+LangGraph's `webhook` field is a bare URL with no delivery policy at all, so this block is a skein
+extension under the reserved namespace, for the same reason `skein.idempotency` is. The **payload
+shape is unchanged** — this configures delivery, not the body.
+
+```jsonc
+{
+  "skein": {
+    "webhooks": {
+      "retries": {
+        "max_attempts": 12, // attempts before a callback is dead, counting the inline first one
+        "initial_delay_ms": 1000, // the first retry's delay; the rest double from it
+      },
+      "max_payload_bytes": 262144, // cap on the stored body; over it, `values` is truncated
+      "retain_hours": 24, // how long a settled delivery is kept before it is reclaimed
+      "allowed_hosts": ["hooks.example.com"], // absent = no restriction (today's behaviour)
+    },
+  },
+}
+```
+
+**This block is tuning, not an on/off switch.** Omitting it does not make callbacks fire-once: a run
+that carries a `webhook` owes a callback, and how hard the server tries is a deployment decision
+rather than permission to try at all. `retries.max_attempts: 1` is how you ask for one shot.
+
+What each one is for:
+
+- `max_attempts` — read it as a **time horizon, not a count**. The delays double, so 12 attempts is
+  1+2+4+…+1024 seconds ≈ **34 minutes**, which rides out a rolling deploy with room to spare. Six is
+  not "half as patient": it is ~31 seconds, which does not survive one redeploy. There is deliberately
+  no ceiling knob — the doubling tops out around 17 minutes at any sane attempt count, and on Redis
+  the schedule is BullMQ's own exponential backoff rather than ours.
+- `initial_delay_ms` — the first retry's delay and the base the rest double from. Raise it for a
+  receiver you know is slow to come back; lower it only if you also lower `max_attempts`.
+- `max_payload_bytes` — the body is **stored** so a retry has something to send, so an unbounded
+  payload is unbounded rows. Over the cap, `values` is replaced by a truncation marker inside the
+  signed body; everything a receiver needs to fetch the state itself survives.
+- `retain_hours` — how long a delivered or dead row is kept. Disk only; nothing is incorrect if the
+  sweep never runs.
+- `allowed_hosts` — an exact-hostname allowlist. Set it if you accept run creates from untrusted
+  callers: `webhook` is a caller-supplied URL, so it is a server-side request to a target they chose,
+  and retrying it turns a one-shot SSRF probe into a repeated one. **Off by default**, because turning
+  it on for everyone would make an upgrade start dropping deployments' own callbacks. A refused host
+  is recorded `dead` with the reason rather than silently skipped.
+
+**Where the retries actually run depends on your queue driver.** With Redis, the whole schedule is
+BullMQ's — delayed jobs, exponential backoff with jitter, and re-delivery of a job whose worker was
+killed — so a retry still waiting survives a restart. Without it, skein polls the outbox instead:
+correct, but the schedule dies with the process, and skein warns at startup when your store is durable
+and your delivery schedule is not. To exercise the production path locally, `skein dev --queue redis`.
+
+Whether a callback is **durable** does not depend on any of this: the delivery is recorded in the same
+transaction as the run's terminal status, so it cannot be lost even with no queue at all. See
+[recipes/production.md](./recipes/production.md#get-notified-when-a-run-finishes).
 
 ## Authentication + authorization (`auth`)
 

--- a/docs/recipes/production.md
+++ b/docs/recipes/production.md
@@ -49,15 +49,48 @@ Pass a `webhook` URL on run creation; skein POSTs the settled run to it.
 await client.runs.create(threadId, "agent", { input, webhook: "https://example.com/hooks/run" });
 ```
 
-**It is best-effort and unsigned.** A failed delivery is logged, never retried, and never fails the run —
-treat it as a notification and the API as the source of truth. Each POST is aborted after
-`SKEIN_WEBHOOK_TIMEOUT_MS` (default 5s), sized against the 8s shutdown budget so a slow receiver can't
-get you killed mid-POST. Delivery happens after the thread's execution lock is released, so a slow target
-no longer blocks other runs on that thread — which also means two webhooks for one thread are not
-guaranteed to arrive in run order.
+**The callback is recorded in the same transaction as the run's terminal status**, so a crash between
+"the run finished" and "someone was told" cannot lose it. That is the guarantee, and it comes from the
+store — not from the retry policy, and not from anything you configure. skein attempts the first
+delivery inline, so a healthy receiver hears within milliseconds; a failure is recorded and retried.
 
-A server accepting untrusted clients should inject a `webhookDispatcher` that allowlists the host.
-Durable, signed, retried delivery is [proposed](../proposals/durable-delivery.md).
+**It is at-least-once, not exactly-once.** A retry can duplicate a callback your receiver already
+processed — after a network timeout that actually succeeded, say. Every attempt carries the same
+`X-Skein-Delivery-Id`; dedupe on it. The API remains the source of truth for run state.
+
+Each POST is aborted after `SKEIN_WEBHOOK_TIMEOUT_MS` (default 5s), sized against the 8s shutdown
+budget so a slow receiver can't get you killed mid-POST. Delivery happens after the thread's execution
+lock is released, so a slow target never blocks other runs on that thread — which also means two
+callbacks for one thread are not guaranteed to arrive in run order.
+
+### Retries are BullMQ's when you run Redis
+
+Where the retry schedule lives depends on the queue driver, and this is the one place it matters:
+
+|                        | Retry schedule                                                               | Survives a restart?                                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Postgres + Redis**   | BullMQ — delayed jobs, exponential backoff with jitter, stalled-job recovery | **Yes.** A retry still waiting is in Redis                                                                              |
+| **Postgres, no Redis** | skein polls the outbox for rows that are due                                 | No. A retry still waiting is lost on exit; the _delivery_ is not — the row is still there and the next boot picks it up |
+| **Memory (dev)**       | Same poll, in-process                                                        | No, and neither is the delivery — nothing here is durable                                                               |
+
+So: **run Redis in production.** skein warns at startup when your store is durable but your delivery
+schedule is not. Want to exercise the real thing locally? `skein dev --queue redis` — the same BullMQ
+path, against a local Redis.
+
+Tune the policy under [`skein.webhooks`](../langgraph-cli-compat.md#webhooks-skeinwebhooks). The
+default is 12 attempts over roughly 34 minutes, which rides out a rolling deploy with room to spare.
+Read that as a **time horizon, not a count**: dropping to 6 attempts is ~31 seconds, which does not
+survive one redeploy.
+
+A server accepting untrusted clients should set `skein.webhooks.allowed_hosts`: `webhook` is a
+caller-supplied URL, so it is a server-side request to a target they chose, and retrying it turns a
+one-shot SSRF probe into a repeated one. It is off by default so upgrading cannot start dropping your
+own callbacks.
+
+Payloads are capped at `max_payload_bytes` (default 256 KiB) because the body is stored for retries.
+Over the cap, `values` is replaced by a truncation marker **inside the body** — so a receiver is told
+it is looking at a truncated state rather than left to infer it. Raise the cap, or read the state back
+from the API using the `run_id` in the callback.
 
 ## Go durable and scale out
 

--- a/docs/recipes/production.md
+++ b/docs/recipes/production.md
@@ -77,6 +77,12 @@ So: **run Redis in production.** skein warns at startup when your store is durab
 schedule is not. Want to exercise the real thing locally? `skein dev --queue redis` — the same BullMQ
 path, against a local Redis.
 
+There is one window neither side can close on its own: a Redis `add()` cannot join a Postgres
+transaction, so a process that dies between committing the delivery and enqueueing its job leaves a
+callback with no schedule. Nothing is lost — the row is committed — and a background sweep re-schedules
+it, idempotently, on its next pass. That is the standard outbox trade: the database is the single
+commit point, and the queue is a schedule rather than a second source of truth.
+
 Tune the policy under [`skein.webhooks`](../langgraph-cli-compat.md#webhooks-skeinwebhooks). The
 default is 12 attempts over roughly 34 minutes, which rides out a rolling deploy with room to spare.
 Read that as a **time horizon, not a count**: dropping to 6 attempts is ~31 seconds, which does not

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5881,6 +5881,12 @@ So: **run Redis in production.** skein warns at startup when your store is durab
 schedule is not. Want to exercise the real thing locally? `skein dev --queue redis` — the same BullMQ
 path, against a local Redis.
 
+There is one window neither side can close on its own: a Redis `add()` cannot join a Postgres
+transaction, so a process that dies between committing the delivery and enqueueing its job leaves a
+callback with no schedule. Nothing is lost — the row is committed — and a background sweep re-schedules
+it, idempotently, on its next pass. That is the standard outbox trade: the database is the single
+commit point, and the queue is a schedule rather than a second source of truth.
+
 Tune the policy under [`skein.webhooks`](../langgraph-cli-compat.md#webhooks-skeinwebhooks). The
 default is 12 attempts over roughly 34 minutes, which rides out a rolling deploy with room to spare.
 Read that as a **time horizon, not a count**: dropping to 6 attempts is ~31 seconds, which does not

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2038,6 +2038,9 @@ it but is never required.
     // Retention for `Idempotency-Key` records (skein extension; see below). Tuning only —
     // omitting the block does NOT disable the header.
     "idempotency": { "retention_hours": 24, "in_flight_minutes": 15 },
+    // Delivery policy for run-completion callbacks (skein extension; see below). Tuning only —
+    // omitting the block does NOT make callbacks fire-once.
+    "webhooks": { "retries": { "max_attempts": 12 }, "allowed_hosts": ["hooks.example.com"] },
   },
 
   // .env path OR inline map
@@ -2097,6 +2100,7 @@ it but is never required.
 | `node_version`         | Used by `skein build` / `skein dockerfile` base image selection. Defaults to Node 24 LTS when omitted; an explicit value is honoured verbatim, including an older one.                                                                                                                                                                                                                                                                             |
 | `skein.runtime`        | Native production server and pinned official image: `node`, `bun`, or `deno`. Bun/Deno use `@skein-js/fetch` with `Bun.serve`/`Deno.serve`, never Express compatibility.                                                                                                                                                                                                                                                                           |
 | `skein.idempotency`    | Retention for `Idempotency-Key` records. Tuning only — the header is honoured either way. See [below](#idempotency-skeinidempotency).                                                                                                                                                                                                                                                                                                              |
+| `skein.webhooks`       | How run-completion callbacks are retried and bounded. Tuning only — a run carrying a `webhook` owes a callback either way. See [below](#webhooks-skeinwebhooks).                                                                                                                                                                                                                                                                                   |
 | `env`                  | Loaded into `process.env` at boot (dev) / baked into the image (build).                                                                                                                                                                                                                                                                                                                                                                            |
 | `store`                | `store.index.{embed,dims,fields,hnsw}` configures pgvector semantic search on the Postgres driver (`hnsw: true` opts into the approximate index); `store.ttl.{default_ttl,refresh_on_read,sweep_interval_minutes}` expires items. `store.adapter` is a **skein extension** — `path:export` to your own LangGraph `BaseStore` (e.g. `PostgresStore`, `MongoDBStore`), which then serves the whole `/store` surface. See [storage.md](./storage.md). |
 | `checkpointer`         | `"default"` → `PostgresSaver`; dev falls back to an in-memory `MemorySaver`.                                                                                                                                                                                                                                                                                                                                                                       |
@@ -2164,6 +2168,62 @@ What each one is for:
 Honoured identically on every driver combination, including `skein dev` with no Docker. See
 [agent-protocol.md](./agent-protocol.md#idempotent-run-creation-idempotency-key) for the request
 semantics and the replay table.
+
+## Webhooks (`skein.webhooks`)
+
+LangGraph's `webhook` field is a bare URL with no delivery policy at all, so this block is a skein
+extension under the reserved namespace, for the same reason `skein.idempotency` is. The **payload
+shape is unchanged** — this configures delivery, not the body.
+
+```jsonc
+{
+  "skein": {
+    "webhooks": {
+      "retries": {
+        "max_attempts": 12, // attempts before a callback is dead, counting the inline first one
+        "initial_delay_ms": 1000, // the first retry's delay; the rest double from it
+      },
+      "max_payload_bytes": 262144, // cap on the stored body; over it, `values` is truncated
+      "retain_hours": 24, // how long a settled delivery is kept before it is reclaimed
+      "allowed_hosts": ["hooks.example.com"], // absent = no restriction (today's behaviour)
+    },
+  },
+}
+```
+
+**This block is tuning, not an on/off switch.** Omitting it does not make callbacks fire-once: a run
+that carries a `webhook` owes a callback, and how hard the server tries is a deployment decision
+rather than permission to try at all. `retries.max_attempts: 1` is how you ask for one shot.
+
+What each one is for:
+
+- `max_attempts` — read it as a **time horizon, not a count**. The delays double, so 12 attempts is
+  1+2+4+…+1024 seconds ≈ **34 minutes**, which rides out a rolling deploy with room to spare. Six is
+  not "half as patient": it is ~31 seconds, which does not survive one redeploy. There is deliberately
+  no ceiling knob — the doubling tops out around 17 minutes at any sane attempt count, and on Redis
+  the schedule is BullMQ's own exponential backoff rather than ours.
+- `initial_delay_ms` — the first retry's delay and the base the rest double from. Raise it for a
+  receiver you know is slow to come back; lower it only if you also lower `max_attempts`.
+- `max_payload_bytes` — the body is **stored** so a retry has something to send, so an unbounded
+  payload is unbounded rows. Over the cap, `values` is replaced by a truncation marker inside the
+  signed body; everything a receiver needs to fetch the state itself survives.
+- `retain_hours` — how long a delivered or dead row is kept. Disk only; nothing is incorrect if the
+  sweep never runs.
+- `allowed_hosts` — an exact-hostname allowlist. Set it if you accept run creates from untrusted
+  callers: `webhook` is a caller-supplied URL, so it is a server-side request to a target they chose,
+  and retrying it turns a one-shot SSRF probe into a repeated one. **Off by default**, because turning
+  it on for everyone would make an upgrade start dropping deployments' own callbacks. A refused host
+  is recorded `dead` with the reason rather than silently skipped.
+
+**Where the retries actually run depends on your queue driver.** With Redis, the whole schedule is
+BullMQ's — delayed jobs, exponential backoff with jitter, and re-delivery of a job whose worker was
+killed — so a retry still waiting survives a restart. Without it, skein polls the outbox instead:
+correct, but the schedule dies with the process, and skein warns at startup when your store is durable
+and your delivery schedule is not. To exercise the production path locally, `skein dev --queue redis`.
+
+Whether a callback is **durable** does not depend on any of this: the delivery is recorded in the same
+transaction as the run's terminal status, so it cannot be lost even with no queue at all. See
+[recipes/production.md](./recipes/production.md#get-notified-when-a-run-finishes).
 
 ## Authentication + authorization (`auth`)
 
@@ -5793,15 +5853,48 @@ Pass a `webhook` URL on run creation; skein POSTs the settled run to it.
 await client.runs.create(threadId, "agent", { input, webhook: "https://example.com/hooks/run" });
 ```
 
-**It is best-effort and unsigned.** A failed delivery is logged, never retried, and never fails the run —
-treat it as a notification and the API as the source of truth. Each POST is aborted after
-`SKEIN_WEBHOOK_TIMEOUT_MS` (default 5s), sized against the 8s shutdown budget so a slow receiver can't
-get you killed mid-POST. Delivery happens after the thread's execution lock is released, so a slow target
-no longer blocks other runs on that thread — which also means two webhooks for one thread are not
-guaranteed to arrive in run order.
+**The callback is recorded in the same transaction as the run's terminal status**, so a crash between
+"the run finished" and "someone was told" cannot lose it. That is the guarantee, and it comes from the
+store — not from the retry policy, and not from anything you configure. skein attempts the first
+delivery inline, so a healthy receiver hears within milliseconds; a failure is recorded and retried.
 
-A server accepting untrusted clients should inject a `webhookDispatcher` that allowlists the host.
-Durable, signed, retried delivery is [proposed](../proposals/durable-delivery.md).
+**It is at-least-once, not exactly-once.** A retry can duplicate a callback your receiver already
+processed — after a network timeout that actually succeeded, say. Every attempt carries the same
+`X-Skein-Delivery-Id`; dedupe on it. The API remains the source of truth for run state.
+
+Each POST is aborted after `SKEIN_WEBHOOK_TIMEOUT_MS` (default 5s), sized against the 8s shutdown
+budget so a slow receiver can't get you killed mid-POST. Delivery happens after the thread's execution
+lock is released, so a slow target never blocks other runs on that thread — which also means two
+callbacks for one thread are not guaranteed to arrive in run order.
+
+### Retries are BullMQ's when you run Redis
+
+Where the retry schedule lives depends on the queue driver, and this is the one place it matters:
+
+|                        | Retry schedule                                                               | Survives a restart?                                                                                                     |
+| ---------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| **Postgres + Redis**   | BullMQ — delayed jobs, exponential backoff with jitter, stalled-job recovery | **Yes.** A retry still waiting is in Redis                                                                              |
+| **Postgres, no Redis** | skein polls the outbox for rows that are due                                 | No. A retry still waiting is lost on exit; the _delivery_ is not — the row is still there and the next boot picks it up |
+| **Memory (dev)**       | Same poll, in-process                                                        | No, and neither is the delivery — nothing here is durable                                                               |
+
+So: **run Redis in production.** skein warns at startup when your store is durable but your delivery
+schedule is not. Want to exercise the real thing locally? `skein dev --queue redis` — the same BullMQ
+path, against a local Redis.
+
+Tune the policy under [`skein.webhooks`](../langgraph-cli-compat.md#webhooks-skeinwebhooks). The
+default is 12 attempts over roughly 34 minutes, which rides out a rolling deploy with room to spare.
+Read that as a **time horizon, not a count**: dropping to 6 attempts is ~31 seconds, which does not
+survive one redeploy.
+
+A server accepting untrusted clients should set `skein.webhooks.allowed_hosts`: `webhook` is a
+caller-supplied URL, so it is a server-side request to a target they chose, and retrying it turns a
+one-shot SSRF probe into a repeated one. It is off by default so upgrading cannot start dropping your
+own callbacks.
+
+Payloads are capped at `max_payload_bytes` (default 256 KiB) because the body is stored for retries.
+Over the cap, `values` is replaced by a truncation marker **inside the body** — so a receiver is told
+it is looking at a truncated state rather than left to infer it. Raise the cap, or read the state back
+from the API using the `run_id` in the callback.
 
 ## Go durable and scale out
 

--- a/packages/agent-protocol/src/deliveries/attempt-delivery.test.ts
+++ b/packages/agent-protocol/src/deliveries/attempt-delivery.test.ts
@@ -1,0 +1,230 @@
+// One delivery attempt, and what it records. This is the only place that decides when a failure is
+// terminal, so both the engine's inline attempt and the worker's retries agree by construction.
+
+import type { Delivery, DeliveryAttemptResult, DeliveryRepo } from "@skein-js/core";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Logger, WebhookDispatcher } from "../deps.js";
+
+import { attemptDelivery, type AttemptDeliveryDeps } from "./attempt-delivery.js";
+import type { WebhookDeliveryConfig } from "./delivery-config.js";
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+/** Collects what was logged, so the "never rejects" cases can prove they reported rather than hid. */
+function collectingLogger() {
+  const errors: string[] = [];
+  const logger: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (message: string) => errors.push(message),
+  };
+  return { logger, errors };
+}
+
+function delivery(overrides: Partial<Delivery> = {}): Delivery {
+  return {
+    delivery_id: "d-1",
+    run_id: "run-1",
+    thread_id: "thread-1",
+    url: "https://hooks.example.test/skein",
+    payload: { run_id: "run-1", values: { answer: 42 } },
+    payload_truncated: false,
+    run_status: "success",
+    status: "delivering",
+    attempt: 1,
+    next_attempt_at: NOW.toISOString(),
+    last_error: null,
+    created_at: NOW.toISOString(),
+    updated_at: NOW.toISOString(),
+    expires_at: NOW.toISOString(),
+    ...overrides,
+  };
+}
+
+/** A `DeliveryRepo` that only records — the rest of the surface is not on this path. */
+function recordingRepo() {
+  const recorded: DeliveryAttemptResult[] = [];
+  const repo = {
+    recordAttempt: vi.fn(async (_id: string, result: DeliveryAttemptResult) => {
+      recorded.push(result);
+      return delivery({ status: result.outcome === "delivered" ? "delivered" : "pending" });
+    }),
+  } as unknown as DeliveryRepo;
+  return { repo, recorded };
+}
+
+function depsFor(
+  dispatch: WebhookDispatcher,
+  repo: DeliveryRepo,
+  webhooks?: WebhookDeliveryConfig,
+  logger: Logger = collectingLogger().logger,
+): AttemptDeliveryDeps {
+  return {
+    store: { deliveries: repo },
+    webhookDispatcher: dispatch,
+    logger,
+    clock: () => NOW,
+    ...(webhooks ? { webhooks } : {}),
+  };
+}
+
+describe("attemptDelivery", () => {
+  it("sends the stored body with the run's committed status merged in", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { repo, recorded } = recordingRepo();
+
+    await attemptDelivery(depsFor(dispatch, repo), delivery({ run_status: "cancelled" }));
+
+    const [url, body, attempt] = dispatch.mock.calls[0]!;
+    expect(url).toBe("https://hooks.example.test/skein");
+    expect(body).toMatchObject({ run_id: "run-1", status: "cancelled" });
+    expect(recorded).toEqual([{ outcome: "delivered" }]);
+    // The dedup key the receiver needs to make at-least-once safe on their side. Shipped with the
+    // retries rather than after them: retrying without it turns our reliability improvement into
+    // their duplicate-processing bug.
+    expect(attempt?.headers).toMatchObject({
+      "x-skein-delivery-id": "d-1",
+      "x-skein-attempt": "1",
+    });
+  });
+
+  it("keeps the delivery id stable across attempts, and moves the attempt number", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { repo } = recordingRepo();
+
+    await attemptDelivery(depsFor(dispatch, repo), delivery({ attempt: 1 }));
+    await attemptDelivery(depsFor(dispatch, repo), delivery({ attempt: 4 }));
+
+    const [first, second] = dispatch.mock.calls;
+    expect(first?.[2]?.headers["x-skein-delivery-id"]).toBe("d-1");
+    // Same id — that is what makes it a dedup key rather than a request id.
+    expect(second?.[2]?.headers["x-skein-delivery-id"]).toBe("d-1");
+    expect(first?.[2]?.headers["x-skein-attempt"]).toBe("1");
+    expect(second?.[2]?.headers["x-skein-attempt"]).toBe("4");
+  });
+
+  it("schedules the next attempt when one is left", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("503 from receiver"));
+    const { repo, recorded } = recordingRepo();
+
+    await attemptDelivery(depsFor(dispatch, repo), delivery({ attempt: 3 }));
+
+    expect(recorded[0]).toMatchObject({ outcome: "retrying", error: "503 from receiver" });
+    // Due in the future, off the injected clock rather than the driver's.
+    const next = (recorded[0] as { nextAttemptAt: string }).nextAttemptAt;
+    expect(new Date(next).getTime()).toBeGreaterThan(NOW.getTime());
+  });
+
+  it("declares a delivery dead once its last attempt fails", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("still down"));
+    const { repo, recorded } = recordingRepo();
+
+    await attemptDelivery(
+      depsFor(dispatch, repo, { retries: { maxAttempts: 3 } }),
+      delivery({ attempt: 3 }),
+    );
+
+    expect(recorded).toEqual([{ outcome: "dead", error: "still down" }]);
+  });
+
+  it("treats max_attempts: 1 as the pre-outbox fire-once behaviour", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("nope"));
+    const { repo, recorded } = recordingRepo();
+
+    await attemptDelivery(
+      depsFor(dispatch, repo, { retries: { maxAttempts: 1 } }),
+      delivery({ attempt: 1 }),
+    );
+
+    expect(recorded[0]?.outcome).toBe("dead");
+  });
+
+  // Both callers depend on this: the engine's `finally` must not turn a failed callback into a failed
+  // run, and the worker's tick must not lose the rest of its batch to one bad receiver.
+  it("never rejects, even when recording the outcome is the thing that fails", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const repo = {
+      recordAttempt: vi.fn().mockRejectedValue(new Error("database gone")),
+    } as unknown as DeliveryRepo;
+    const { logger, errors } = collectingLogger();
+
+    // Resolves rather than throws, and says so in the log. The row keeps its lease, so the next
+    // claim retries it — one duplicate POST, which at-least-once already permits.
+    expect(
+      await attemptDelivery(depsFor(dispatch, repo, undefined, logger), delivery()),
+    ).toBeNull();
+    expect(errors.join("\n")).toContain("could not record");
+  });
+
+  // The bug this guards: wrapping the POST and the record in one `try` reads a database blip *after*
+  // a successful POST as a failed delivery, schedules a retry, and so POSTs a second time to a
+  // receiver that already has it.
+  it("does not schedule a retry when the POST succeeded and only the record failed", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const recordAttempt = vi.fn().mockRejectedValue(new Error("database gone"));
+    const repo = { recordAttempt } as unknown as DeliveryRepo;
+
+    await attemptDelivery(depsFor(dispatch, repo), delivery());
+
+    expect(recordAttempt).toHaveBeenCalledTimes(1);
+    expect(recordAttempt.mock.calls[0]![1]).toEqual({ outcome: "delivered" });
+  });
+
+  it("kills a delivery to a host outside the allowlist without trying it", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { repo, recorded } = recordingRepo();
+
+    await attemptDelivery(
+      depsFor(dispatch, repo, { allowedHosts: ["hooks.allowed.test"] }),
+      delivery({ url: "https://169.254.169.254/latest/meta-data" }),
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    // Dead rather than retried: no number of attempts makes a disallowed host allowed. Recorded
+    // rather than skipped, so it shows up as a failed delivery instead of a callback that vanished.
+    expect(recorded[0]).toMatchObject({ outcome: "dead" });
+    expect((recorded[0] as { error: string }).error).toContain("allowed_hosts");
+  });
+
+  it("matches an allowlisted host exactly, not by suffix", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { repo, recorded } = recordingRepo();
+
+    // The classic way an allowlist stops being one: "example.test" also admitting "notexample.test".
+    await attemptDelivery(
+      depsFor(dispatch, repo, { allowedHosts: ["example.test"] }),
+      delivery({ url: "https://notexample.test/hook" }),
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(recorded[0]?.outcome).toBe("dead");
+  });
+
+  it("sends to a host that is on the allowlist", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { repo, recorded } = recordingRepo();
+
+    await attemptDelivery(
+      depsFor(dispatch, repo, { allowedHosts: ["hooks.example.test"] }),
+      delivery(),
+    );
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(recorded).toEqual([{ outcome: "delivered" }]);
+  });
+
+  it("does nothing on a store with no deliveries repo", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const deps = {
+      store: {},
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock: () => NOW,
+    } as AttemptDeliveryDeps;
+
+    expect(await attemptDelivery(deps, delivery())).toBeNull();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agent-protocol/src/deliveries/attempt-delivery.test.ts
+++ b/packages/agent-protocol/src/deliveries/attempt-delivery.test.ts
@@ -172,6 +172,64 @@ describe("attemptDelivery", () => {
     expect(recordAttempt.mock.calls[0]![1]).toEqual({ outcome: "delivered" });
   });
 
+  // Regression: this branch used to return the store write unguarded, so a store failure rejected a
+  // function documented never to reject — and the engine awaits it inside a `finally`, so the
+  // rejection escaped and skipped the cleanup after it (a leaked control-registry entry, an undeleted
+  // stateless thread, and a 500 on a run that actually succeeded).
+  it("does not reject when the store fails while refusing a disallowed host", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const repo = {
+      recordAttempt: vi.fn().mockRejectedValue(new Error("database gone")),
+    } as unknown as DeliveryRepo;
+    const { logger, errors } = collectingLogger();
+
+    expect(
+      await attemptDelivery(
+        depsFor(dispatch, repo, { allowedHosts: ["hooks.allowed.test"] }, logger),
+        delivery({ url: "https://elsewhere.test/hook" }),
+      ),
+    ).toBeNull();
+    expect(errors.join("\n")).toContain("could not record");
+  });
+
+  // Regression: the row is written first, with `next_attempt_at` hours out because a queue was
+  // supposed to own the schedule. When the hand-off fails, nothing does — so a momentary Redis blip
+  // turned a one-second retry into a multi-hour one.
+  it("falls back to the polling schedule when the queue will not take the retry", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("503"));
+    const { repo, recorded } = recordingRepo();
+    const { logger, errors } = collectingLogger();
+    const deliveryQueue = {
+      schedule: vi.fn().mockRejectedValue(new Error("redis is down")),
+      consume: () => ({ close: async () => {} }),
+      durable: true,
+    };
+
+    await attemptDelivery(
+      { ...depsFor(dispatch, repo, { retries: { maxAttempts: 12 } }, logger), deliveryQueue },
+      delivery({ attempt: 1 }),
+    );
+
+    expect(errors.join("\n")).toContain("could not hand the retry");
+    // Rewritten to the ordinary backoff — seconds — rather than left at the sweep's hours-long grace.
+    const rewritten = recorded.at(-1) as { nextAttemptAt: string };
+    expect(new Date(rewritten.nextAttemptAt).getTime() - NOW.getTime()).toBeLessThan(60_000);
+  });
+
+  it("hands the retry to the queue with the attempts it has left", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("503"));
+    const { repo } = recordingRepo();
+    const schedule = vi.fn().mockResolvedValue(undefined);
+    const deliveryQueue = { schedule, consume: () => ({ close: async () => {} }), durable: true };
+
+    await attemptDelivery(
+      { ...depsFor(dispatch, repo, { retries: { maxAttempts: 12 } }), deliveryQueue },
+      delivery({ attempt: 1 }),
+    );
+
+    expect(schedule.mock.calls[0]![1]).toMatchObject({ attempts: 11 });
+  });
+
   it("kills a delivery to a host outside the allowlist without trying it", async () => {
     const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
     const { repo, recorded } = recordingRepo();

--- a/packages/agent-protocol/src/deliveries/attempt-delivery.ts
+++ b/packages/agent-protocol/src/deliveries/attempt-delivery.ts
@@ -11,7 +11,7 @@ import { deliveryHeaders, type Logger, type WebhookDispatcher } from "../deps.js
 
 import { isFinalAttempt, nextAttemptDelayMs } from "./backoff.js";
 import {
-  queueSweepGraceMs,
+  QUEUE_SWEEP_MARGIN_MS,
   remainingQueueAttempts,
   type WebhookDeliveryConfig,
 } from "./delivery-config.js";
@@ -162,11 +162,12 @@ function failureResult(
   if (isFinalAttempt(delivery.attempt, deps.webhooks?.retries)) {
     return { outcome: "dead", error: message };
   }
-  // With a queue, `next_attempt_at` is not a schedule — the queue holds that — so it is pushed far
-  // enough out that the recovery sweep only ever sees a delivery whose job is genuinely lost.
-  const dueInMs = deps.deliveryQueue
-    ? queueSweepGraceMs(deps.webhooks?.retries)
-    : nextAttemptDelayMs(delivery.attempt, deps.webhooks?.retries);
+  // With a queue, `next_attempt_at` is not the schedule — the queue holds that — but it is still when
+  // the recovery sweep starts looking, so it stays close to the real next attempt plus a margin. Long
+  // enough that the sweep does not race an ordinary retry; short enough that a job lost to a crash is
+  // found on the next pass rather than hours later.
+  const delayMs = nextAttemptDelayMs(delivery.attempt, deps.webhooks?.retries);
+  const dueInMs = deps.deliveryQueue ? delayMs + QUEUE_SWEEP_MARGIN_MS : delayMs;
   return {
     outcome: "retrying",
     nextAttemptAt: new Date(deps.clock().getTime() + dueInMs).toISOString(),

--- a/packages/agent-protocol/src/deliveries/attempt-delivery.ts
+++ b/packages/agent-protocol/src/deliveries/attempt-delivery.ts
@@ -11,8 +11,8 @@ import { deliveryHeaders, type Logger, type WebhookDispatcher } from "../deps.js
 
 import { isFinalAttempt, nextAttemptDelayMs } from "./backoff.js";
 import {
-  DEFAULT_MAX_ATTEMPTS,
   queueSweepGraceMs,
+  remainingQueueAttempts,
   type WebhookDeliveryConfig,
 } from "./delivery-config.js";
 import { toDeliveryBody } from "./delivery-payload.js";
@@ -52,13 +52,36 @@ export async function attemptDelivery(
   const deliveries = deps.store.deliveries;
   if (!deliveries) return null;
 
+  /**
+   * Record an outcome without ever rejecting.
+   *
+   * Every write in this function goes through here. An unguarded one would break the contract in the
+   * worst possible place: the engine awaits this inside a `finally`, so a rejection escapes into
+   * `startRunExecution` and skips the cleanup that follows it — leaving a run registered in the
+   * control registry and a stateless run's thread undeleted, and turning a successful run into a 500.
+   */
+  const record = async (result: DeliveryAttemptResult): Promise<Delivery | null> => {
+    try {
+      return await deliveries.recordAttempt(delivery.delivery_id, result);
+    } catch (error) {
+      // Bounded and self-healing: the row keeps its lease, so the next claim attempts it again. That
+      // is one duplicate POST, which at-least-once already permits and the delivery id absorbs.
+      deps.logger.error(
+        `delivery ${delivery.delivery_id}: could not record a ${result.outcome} attempt; ` +
+          `it stays leased and will be retried`,
+        error,
+      );
+      return null;
+    }
+  };
+
   const disallowed = disallowedHost(delivery.url, deps.webhooks?.allowedHosts);
   if (disallowed) {
     // Dead on the spot rather than retried: no number of attempts makes a disallowed host allowed,
     // and recording it is what keeps this visible in the delivery list instead of being a callback
     // that simply never arrives.
     deps.logger.warn(`delivery ${delivery.delivery_id}: ${disallowed}`);
-    return deliveries.recordAttempt(delivery.delivery_id, { outcome: "dead", error: disallowed });
+    return record({ outcome: "dead", error: disallowed });
   }
 
   const sentAt = deps.clock().toISOString();
@@ -94,38 +117,38 @@ export async function attemptDelivery(
     );
   }
 
+  const settled = await record(result);
+  if (result.outcome !== "retrying" || !deps.deliveryQueue) return settled;
+
+  // Handed over rather than left for a poller. `schedule` is idempotent on the delivery id, so a
+  // recovery sweep that cannot prove this happened may safely repeat it.
   try {
-    const settled = await deliveries.recordAttempt(delivery.delivery_id, result);
-    if (result.outcome === "retrying" && deps.deliveryQueue) {
-      // Handed over rather than left for a poller. `schedule` is idempotent on the delivery id, so a
-      // recovery sweep that cannot prove this happened may safely repeat it.
-      await deps.deliveryQueue.schedule(
-        { delivery_id: delivery.delivery_id },
-        {
-          // The delay for *this* retry is ours, because the queue's own backoff only spaces attempts
-          // it made itself and this one was made inline. Every subsequent delay is the queue's.
-          delayMs: nextAttemptDelayMs(delivery.attempt, deps.webhooks?.retries),
-          // What is left of the budget after the inline attempt and this one.
-          attempts: Math.max(
-            1,
-            (deps.webhooks?.retries?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS) - delivery.attempt,
-          ),
-        },
-      );
-    }
+    await deps.deliveryQueue.schedule(
+      { delivery_id: delivery.delivery_id },
+      {
+        // The delay for *this* retry is ours, because the queue's own backoff only spaces attempts
+        // it made itself and this one was made inline. Every subsequent delay is the queue's.
+        delayMs: nextAttemptDelayMs(delivery.attempt, deps.webhooks?.retries),
+        attempts: remainingQueueAttempts(delivery.attempt, deps.webhooks?.retries),
+      },
+    );
     return settled;
   } catch (error) {
-    // Swallowed, so this function keeps its promise never to reject — its two callers both need
-    // that. The cost of losing the write is bounded and self-healing: the row keeps its lease, and
-    // the next `claimDue` after the lease expires simply attempts it again. That is one duplicate
-    // POST, which at-least-once already permits, against a rejection here propagating into the
-    // engine's `finally` or killing the rest of the worker's batch.
+    // The hand-off failed, so nothing owns this delivery's schedule — and the row was written on the
+    // assumption that something did, with `next_attempt_at` hours out where the sweep would not look
+    // for it until then. Pull it back onto the polling schedule so the sweep picks it up on its next
+    // pass. Without this, a momentary Redis blip turns a one-second retry into a multi-hour one.
     deps.logger.error(
-      `delivery ${delivery.delivery_id}: could not record a ${result.outcome} attempt; ` +
-        `it stays leased and will be retried`,
+      `delivery ${delivery.delivery_id}: could not hand the retry to the delivery queue; ` +
+        `falling back to the polling schedule`,
       error,
     );
-    return null;
+    return record({
+      ...result,
+      nextAttemptAt: new Date(
+        deps.clock().getTime() + nextAttemptDelayMs(delivery.attempt, deps.webhooks?.retries),
+      ).toISOString(),
+    });
   }
 }
 

--- a/packages/agent-protocol/src/deliveries/attempt-delivery.ts
+++ b/packages/agent-protocol/src/deliveries/attempt-delivery.ts
@@ -1,0 +1,152 @@
+// One delivery attempt: send it, then record what happened.
+//
+// Used by **both** the engine's inline first attempt and the delivery worker's retries, so there is
+// exactly one place that decides what an attempt is, when a failure is terminal, and when the next
+// one is due. Two copies of that would drift, and the way they would drift is a delivery that the
+// engine considers dead and the worker keeps retrying.
+
+import type { Delivery, DeliveryAttemptResult, DeliveryQueue, SkeinStore } from "@skein-js/core";
+
+import { deliveryHeaders, type Logger, type WebhookDispatcher } from "../deps.js";
+
+import { isFinalAttempt, nextAttemptDelayMs } from "./backoff.js";
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  queueSweepGraceMs,
+  type WebhookDeliveryConfig,
+} from "./delivery-config.js";
+import { toDeliveryBody } from "./delivery-payload.js";
+import { disallowedHost } from "./delivery-target.js";
+
+export interface AttemptDeliveryDeps {
+  store: Pick<SkeinStore, "deliveries">;
+  webhookDispatcher: WebhookDispatcher;
+  logger: Logger;
+  clock: () => Date;
+  webhooks?: WebhookDeliveryConfig;
+  /**
+   * Where the retry goes when this attempt fails. Present in a Redis deployment, absent in
+   * development — see {@link DeliveryQueue}.
+   *
+   * With a queue, **every decision about when to try again belongs to it**: this records what
+   * happened and hands the delivery over, and the row's `next_attempt_at` becomes a lost-job marker
+   * for the recovery sweep rather than a schedule. Without one, the row's `next_attempt_at` *is* the
+   * schedule and the polling worker reads it.
+   */
+  deliveryQueue?: DeliveryQueue;
+}
+
+/**
+ * Attempt `delivery` once and record the outcome. Resolves to the settled row, or `null` if the
+ * delivery vanished under us.
+ *
+ * **Never rejects.** Its two callers both need that: the engine's `finally` must not turn a failed
+ * callback into a failed run, and the worker's tick must not lose the rest of its batch to one bad
+ * receiver. A failure becomes a recorded attempt, which is the whole point — today's dispatcher
+ * swallows the error into a log line and nothing remembers it happened.
+ */
+export async function attemptDelivery(
+  deps: AttemptDeliveryDeps,
+  delivery: Delivery,
+): Promise<Delivery | null> {
+  const deliveries = deps.store.deliveries;
+  if (!deliveries) return null;
+
+  const disallowed = disallowedHost(delivery.url, deps.webhooks?.allowedHosts);
+  if (disallowed) {
+    // Dead on the spot rather than retried: no number of attempts makes a disallowed host allowed,
+    // and recording it is what keeps this visible in the delivery list instead of being a callback
+    // that simply never arrives.
+    deps.logger.warn(`delivery ${delivery.delivery_id}: ${disallowed}`);
+    return deliveries.recordAttempt(delivery.delivery_id, { outcome: "dead", error: disallowed });
+  }
+
+  const sentAt = deps.clock().toISOString();
+  // The POST is caught on its own, NOT in a try that also wraps the record below. Wrapping both
+  // would misread a database blip *after* a successful POST as a failed delivery — scheduling a
+  // retry, and so a second POST, for a callback the receiver already has.
+  let dispatchFailure: { cause: unknown } | undefined;
+  try {
+    await deps.webhookDispatcher(delivery.url, toDeliveryBody(delivery, sentAt), {
+      deliveryId: delivery.delivery_id,
+      attempt: delivery.attempt,
+      headers: deliveryHeaders(delivery.delivery_id, delivery.attempt),
+    });
+  } catch (cause) {
+    dispatchFailure = { cause };
+  }
+
+  const result: DeliveryAttemptResult = dispatchFailure
+    ? failureResult(deps, delivery, dispatchFailure.cause)
+    : { outcome: "delivered" };
+
+  if (result.outcome === "dead") {
+    // Logged at error, unlike a retry: this is the last word on a callback nobody received, and it
+    // is the line an operator greps for before reaching for the replay endpoint.
+    deps.logger.error(
+      `delivery ${delivery.delivery_id} to ${delivery.url} is dead after ${delivery.attempt} attempt(s)`,
+      dispatchFailure?.cause,
+    );
+  } else if (dispatchFailure) {
+    deps.logger.warn(
+      `delivery ${delivery.delivery_id} to ${delivery.url} failed (attempt ${delivery.attempt}); retrying`,
+      dispatchFailure.cause,
+    );
+  }
+
+  try {
+    const settled = await deliveries.recordAttempt(delivery.delivery_id, result);
+    if (result.outcome === "retrying" && deps.deliveryQueue) {
+      // Handed over rather than left for a poller. `schedule` is idempotent on the delivery id, so a
+      // recovery sweep that cannot prove this happened may safely repeat it.
+      await deps.deliveryQueue.schedule(
+        { delivery_id: delivery.delivery_id },
+        {
+          // The delay for *this* retry is ours, because the queue's own backoff only spaces attempts
+          // it made itself and this one was made inline. Every subsequent delay is the queue's.
+          delayMs: nextAttemptDelayMs(delivery.attempt, deps.webhooks?.retries),
+          // What is left of the budget after the inline attempt and this one.
+          attempts: Math.max(
+            1,
+            (deps.webhooks?.retries?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS) - delivery.attempt,
+          ),
+        },
+      );
+    }
+    return settled;
+  } catch (error) {
+    // Swallowed, so this function keeps its promise never to reject — its two callers both need
+    // that. The cost of losing the write is bounded and self-healing: the row keeps its lease, and
+    // the next `claimDue` after the lease expires simply attempts it again. That is one duplicate
+    // POST, which at-least-once already permits, against a rejection here propagating into the
+    // engine's `finally` or killing the rest of the worker's batch.
+    deps.logger.error(
+      `delivery ${delivery.delivery_id}: could not record a ${result.outcome} attempt; ` +
+        `it stays leased and will be retried`,
+      error,
+    );
+    return null;
+  }
+}
+
+/** Classify a failed attempt: out of attempts is `dead`, anything else is due again later. */
+function failureResult(
+  deps: AttemptDeliveryDeps,
+  delivery: Delivery,
+  error: unknown,
+): DeliveryAttemptResult {
+  const message = error instanceof Error ? error.message : String(error);
+  if (isFinalAttempt(delivery.attempt, deps.webhooks?.retries)) {
+    return { outcome: "dead", error: message };
+  }
+  // With a queue, `next_attempt_at` is not a schedule — the queue holds that — so it is pushed far
+  // enough out that the recovery sweep only ever sees a delivery whose job is genuinely lost.
+  const dueInMs = deps.deliveryQueue
+    ? queueSweepGraceMs(deps.webhooks?.retries)
+    : nextAttemptDelayMs(delivery.attempt, deps.webhooks?.retries);
+  return {
+    outcome: "retrying",
+    nextAttemptAt: new Date(deps.clock().getTime() + dueInMs).toISOString(),
+    error: message,
+  };
+}

--- a/packages/agent-protocol/src/deliveries/backoff.test.ts
+++ b/packages/agent-protocol/src/deliveries/backoff.test.ts
@@ -1,0 +1,90 @@
+// The retry schedule, asserted as a **time horizon** rather than as a sequence of delays.
+//
+// A count of attempts is not something an operator can evaluate. "12 attempts" tells you nothing
+// about whether a delivery survives a rolling deploy; "34 minutes" tells you immediately. So the load
+// bearing assertion here is the sum, and the individual delays only matter insofar as they produce it.
+
+import { describe, expect, it } from "vitest";
+
+import { isFinalAttempt, nextAttemptDelayMs } from "./backoff.js";
+import { DEFAULT_MAX_ATTEMPTS } from "./delivery-config.js";
+
+/** Total wait across every retry a delivery gets, with jitter pinned to its midpoint. */
+function horizonMs(maxAttempts: number, initialDelayMs = 1_000): number {
+  let total = 0;
+  for (let attempt = 1; attempt < maxAttempts; attempt += 1) {
+    // 0.5 draws the midpoint of the jitter window, i.e. 90% of the undithered delay.
+    total += nextAttemptDelayMs(attempt, { maxAttempts, initialDelayMs }, () => 0.5);
+  }
+  return total;
+}
+
+describe("delivery backoff", () => {
+  it("gives the default policy a horizon of roughly half an hour", () => {
+    // 1+2+4+…+1024 seconds. The number in the docs and the config comment is this one; if the
+    // defaults change, this fails and both have to be restated rather than quietly drifting.
+    const minutes = horizonMs(DEFAULT_MAX_ATTEMPTS) / 60_000;
+    expect(minutes).toBeGreaterThan(25);
+    expect(minutes).toBeLessThan(40);
+  });
+
+  it("clears a one-minute receiver outage well inside the default attempts", () => {
+    // The goal the whole outbox exists for: a receiver down for a minute still gets its callback.
+    let elapsed = 0;
+    let attempt = 1;
+    while (elapsed < 60_000 && attempt < DEFAULT_MAX_ATTEMPTS) {
+      elapsed += nextAttemptDelayMs(attempt, {}, () => 0.5);
+      attempt += 1;
+    }
+    expect(elapsed).toBeGreaterThanOrEqual(60_000);
+    // Reached with attempts to spare — the margin is the point, not the exact number.
+    expect(attempt).toBeLessThan(DEFAULT_MAX_ATTEMPTS);
+  });
+
+  it("shows why a smaller attempt count is not a smaller version of the same policy", () => {
+    // 6 attempts reads like "half as patient as 12". It is ~31 seconds against ~34 minutes: it does
+    // not survive one redeploy. This case exists so that trade-off is visible rather than arithmetic
+    // an operator has to do themselves.
+    expect(horizonMs(6) / 1_000).toBeLessThan(35);
+  });
+
+  it("doubles from the initial delay, counting the inline attempt as the first", () => {
+    const fixed = { initialDelayMs: 1_000 };
+    // Attempt 1 already happened inline, so the *first* retry waits the initial delay, not twice it.
+    // 90% of 1s / 2s / 16s — the jitter window's midpoint.
+    expect(nextAttemptDelayMs(1, fixed, () => 0.5)).toBe(900);
+    expect(nextAttemptDelayMs(2, fixed, () => 0.5)).toBe(1_800);
+    expect(nextAttemptDelayMs(5, fixed, () => 0.5)).toBe(14_400);
+  });
+
+  it("keeps the longest default delay well inside an hour, which is why there is no ceiling knob", () => {
+    // Stated as a test because the config comment claims it, and because it is the argument for a
+    // public option we deliberately did not ship: a reader should not have to take it on prose.
+    const largest = nextAttemptDelayMs(DEFAULT_MAX_ATTEMPTS - 1, {}, () => 0.99);
+    expect(largest).toBeLessThan(3_600_000);
+  });
+
+  it("jitters either side of the delay, so a shared outage does not retry in lockstep", () => {
+    const fixed = { initialDelayMs: 1_000 };
+    // Without jitter, every delivery that failed against one receiver during one outage would come
+    // back at exactly the same instant — a synchronized herd of precisely the requests that just
+    // overwhelmed it.
+    // The shape is BullMQ's: a uniform draw from [delay * (1 - jitter), delay). Matching it exactly
+    // is what keeps one retry policy from meaning two different things across the two drivers.
+    expect(nextAttemptDelayMs(1, fixed, () => 0)).toBe(800);
+    expect(nextAttemptDelayMs(1, fixed, () => 0.999)).toBe(999);
+  });
+
+  it("never returns a negative delay", () => {
+    expect(nextAttemptDelayMs(1, { initialDelayMs: 1 }, () => 0)).toBeGreaterThanOrEqual(0);
+  });
+
+  it("calls the last attempt final, and only the last", () => {
+    expect(isFinalAttempt(11, { maxAttempts: 12 })).toBe(false);
+    expect(isFinalAttempt(12, { maxAttempts: 12 })).toBe(true);
+    // Past the bound too, so a policy lowered under a delivery already in flight still terminates.
+    expect(isFinalAttempt(13, { maxAttempts: 12 })).toBe(true);
+    // `max_attempts: 1` is how a deployment asks for the pre-outbox fire-once behaviour.
+    expect(isFinalAttempt(1, { maxAttempts: 1 })).toBe(true);
+  });
+});

--- a/packages/agent-protocol/src/deliveries/backoff.test.ts
+++ b/packages/agent-protocol/src/deliveries/backoff.test.ts
@@ -7,11 +7,7 @@
 import { describe, expect, it } from "vitest";
 
 import { isFinalAttempt, nextAttemptDelayMs } from "./backoff.js";
-import {
-  DEFAULT_MAX_ATTEMPTS,
-  queueSweepGraceMs,
-  remainingQueueAttempts,
-} from "./delivery-config.js";
+import { DEFAULT_MAX_ATTEMPTS, remainingQueueAttempts } from "./delivery-config.js";
 
 /** Total wait across every retry a delivery gets, with jitter pinned to its midpoint. */
 function horizonMs(maxAttempts: number, initialDelayMs = 1_000): number {
@@ -83,14 +79,14 @@ describe("delivery backoff", () => {
     expect(nextAttemptDelayMs(1, { initialDelayMs: 1 }, () => 0)).toBeGreaterThanOrEqual(0);
   });
 
-  // Regression: `2 ** attempts` runs to `Infinity` well before the schema's only bound
-  // (`.positive()`) stops you, and `new Date(Infinity).toISOString()` throws a `RangeError` — from a
-  // code path whose whole contract is that it does not throw.
-  it("keeps the sweep grace finite however many attempts are configured", () => {
-    for (const maxAttempts of [12, 43, 1_000, Number.MAX_SAFE_INTEGER]) {
-      const grace = queueSweepGraceMs({ maxAttempts });
-      expect(Number.isFinite(grace)).toBe(true);
-      expect(() => new Date(Date.now() + grace).toISOString()).not.toThrow();
+  // Regression: `2 ** attempt` runs to `Infinity` well before the schema's only bound (`.positive()`)
+  // stops you, and a caller turning that into `new Date(now + delay).toISOString()` gets a
+  // `RangeError` — from a code path whose whole contract is that it does not throw.
+  it("stays finite however many attempts are configured", () => {
+    for (const attempt of [12, 43, 1_000, Number.MAX_SAFE_INTEGER]) {
+      const delay = nextAttemptDelayMs(attempt, { maxAttempts: attempt });
+      expect(Number.isFinite(delay)).toBe(true);
+      expect(() => new Date(Date.now() + delay).toISOString()).not.toThrow();
     }
   });
 

--- a/packages/agent-protocol/src/deliveries/backoff.test.ts
+++ b/packages/agent-protocol/src/deliveries/backoff.test.ts
@@ -7,7 +7,11 @@
 import { describe, expect, it } from "vitest";
 
 import { isFinalAttempt, nextAttemptDelayMs } from "./backoff.js";
-import { DEFAULT_MAX_ATTEMPTS } from "./delivery-config.js";
+import {
+  DEFAULT_MAX_ATTEMPTS,
+  queueSweepGraceMs,
+  remainingQueueAttempts,
+} from "./delivery-config.js";
 
 /** Total wait across every retry a delivery gets, with jitter pinned to its midpoint. */
 function horizonMs(maxAttempts: number, initialDelayMs = 1_000): number {
@@ -77,6 +81,23 @@ describe("delivery backoff", () => {
 
   it("never returns a negative delay", () => {
     expect(nextAttemptDelayMs(1, { initialDelayMs: 1 }, () => 0)).toBeGreaterThanOrEqual(0);
+  });
+
+  // Regression: `2 ** attempts` runs to `Infinity` well before the schema's only bound
+  // (`.positive()`) stops you, and `new Date(Infinity).toISOString()` throws a `RangeError` — from a
+  // code path whose whole contract is that it does not throw.
+  it("keeps the sweep grace finite however many attempts are configured", () => {
+    for (const maxAttempts of [12, 43, 1_000, Number.MAX_SAFE_INTEGER]) {
+      const grace = queueSweepGraceMs({ maxAttempts });
+      expect(Number.isFinite(grace)).toBe(true);
+      expect(() => new Date(Date.now() + grace).toISOString()).not.toThrow();
+    }
+  });
+
+  it("never offers a queue fewer than one attempt", () => {
+    expect(remainingQueueAttempts(1, { maxAttempts: 12 })).toBe(11);
+    // A policy lowered under a delivery already in flight must not produce a zero or negative budget.
+    expect(remainingQueueAttempts(20, { maxAttempts: 12 })).toBe(1);
   });
 
   it("calls the last attempt final, and only the last", () => {

--- a/packages/agent-protocol/src/deliveries/backoff.ts
+++ b/packages/agent-protocol/src/deliveries/backoff.ts
@@ -16,6 +16,9 @@ import {
  */
 const JITTER_FRACTION = 0.2;
 
+/** The ceiling any single delay is clamped to. Internal, not a config knob — see the note below. */
+const MAX_ATTEMPT_DELAY_MS = 24 * 3_600_000;
+
 /**
  * How long to wait after `attempt` failed, before the next one.
  *
@@ -33,7 +36,15 @@ export function nextAttemptDelayMs(
 ): number {
   const initial = retries.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
   // `attempt` counts from 1, so the first retry waits `initial` rather than twice it.
-  const ceiling = Math.round(initial * 2 ** Math.max(0, attempt - 1));
+  //
+  // Clamped, and not for tidiness: the schema bounds `max_attempts` only by `.positive()`, so a few
+  // dozen attempts sends `2 ** attempt` past `Number.MAX_SAFE_INTEGER` and on to `Infinity` — and a
+  // caller turning that into `new Date(now + delay).toISOString()` gets a `RangeError` from a path
+  // whose contract is that it does not throw. A day is longer than any real schedule needs.
+  const ceiling = Math.min(
+    Math.round(initial * 2 ** Math.max(0, attempt - 1)),
+    MAX_ATTEMPT_DELAY_MS,
+  );
   const floor = ceiling * (1 - JITTER_FRACTION);
   return Math.floor(random() * ceiling * JITTER_FRACTION + floor);
 }

--- a/packages/agent-protocol/src/deliveries/backoff.ts
+++ b/packages/agent-protocol/src/deliveries/backoff.ts
@@ -1,0 +1,44 @@
+// When to try a failed delivery again.
+
+import {
+  DEFAULT_INITIAL_DELAY_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  type DeliveryRetryConfig,
+} from "./delivery-config.js";
+
+/**
+ * How much of the computed delay is randomized away.
+ *
+ * The shape — a uniform draw from `[delay * (1 - jitter), delay)` — is copied from BullMQ's built-in
+ * exponential strategy on purpose. This function is the **development** driver's schedule; on Redis
+ * the schedule is BullMQ's own, and a policy that meant two different things depending on which
+ * queue you deployed would be worse than no policy.
+ */
+const JITTER_FRACTION = 0.2;
+
+/**
+ * How long to wait after `attempt` failed, before the next one.
+ *
+ * Exponential, clamped, then jittered. The jitter is the part that matters at scale and is easy to
+ * leave out: without it, every delivery that failed against one receiver during one outage retries in
+ * lockstep forever after, so the receiver comes back up into a synchronized thundering herd of exactly
+ * the requests that just overwhelmed it.
+ *
+ * `random` is injected so a test can pin the jitter; it defaults to `Math.random`.
+ */
+export function nextAttemptDelayMs(
+  attempt: number,
+  retries: DeliveryRetryConfig = {},
+  random: () => number = Math.random,
+): number {
+  const initial = retries.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  // `attempt` counts from 1, so the first retry waits `initial` rather than twice it.
+  const ceiling = Math.round(initial * 2 ** Math.max(0, attempt - 1));
+  const floor = ceiling * (1 - JITTER_FRACTION);
+  return Math.floor(random() * ceiling * JITTER_FRACTION + floor);
+}
+
+/** True when `attempt` was the last one this delivery gets, so a failure now is terminal. */
+export function isFinalAttempt(attempt: number, retries: DeliveryRetryConfig = {}): boolean {
+  return attempt >= (retries.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+}

--- a/packages/agent-protocol/src/deliveries/delivery-config.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-config.ts
@@ -76,25 +76,19 @@ export const DEFAULT_DELIVERY_POLL_INTERVAL_MS = 5_000;
 export const DEFAULT_DELIVERY_BATCH_SIZE = 20;
 
 /**
- * How long a delivery is invisible to the recovery sweep once a queue has taken charge of it.
+ * How long past its due time a queue-scheduled delivery is left alone before the recovery sweep
+ * treats its job as lost.
  *
- * When a `DeliveryQueue` owns the schedule, the row's `next_attempt_at` stops meaning "try again at"
- * and starts meaning "assume the job is lost after". So it is set to the whole remaining schedule,
- * doubled: being too generous costs a lost job sitting a while longer, while being too tight has the
- * sweep re-attempting a delivery the queue is merely holding — collapsing the backoff it is applying.
+ * A **margin, not a hiding place.** The sweep re-schedules what it finds, and scheduling is
+ * idempotent on the delivery id, so a sweep that overlaps a job the queue is merely holding costs
+ * nothing — which is exactly why this can be a minute rather than the whole remaining schedule. It is
+ * only large enough that the sweep does not race the queue on every ordinary retry.
+ *
+ * This is what makes a lost enqueue recoverable within a sweep interval instead of within hours. It
+ * is safe only because the sweep reads with {@link DeliveryRepo.listDue} rather than claiming: a
+ * claiming sweep would spend the attempt budget of every delivery it looked at.
  */
-export function queueSweepGraceMs(retries?: DeliveryRetryConfig): number {
-  const initial = retries?.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
-  const attempts = retries?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  // Clamped, and not merely for tidiness: the schema bounds `max_attempts` only by `.positive()`, so
-  // a config with a few dozen attempts sends `2 ** attempts` past `Number.MAX_SAFE_INTEGER` and on to
-  // `Infinity` — and `new Date(Infinity).toISOString()` throws a `RangeError`, from a code path whose
-  // whole contract is that it does not throw. A day is far longer than any real schedule needs.
-  return Math.min(initial * 2 ** Math.min(attempts, 32) * 2, MAX_SWEEP_GRACE_MS);
-}
-
-/** The ceiling on {@link queueSweepGraceMs}. */
-const MAX_SWEEP_GRACE_MS = 24 * 3_600_000;
+export const QUEUE_SWEEP_MARGIN_MS = 60_000;
 
 /**
  * How many attempts are left for a queue to make, given how many have already happened.

--- a/packages/agent-protocol/src/deliveries/delivery-config.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-config.ts
@@ -1,0 +1,99 @@
+// How outbound run-completion deliveries are retried, bounded and (in PR 3) signed — the engine's
+// camelCase view of `langgraph.json`'s `skein.webhooks` block.
+//
+// Absence means **defaults, not off**, in the register `IdempotencyConfig` uses: a caller who passed a
+// `webhook` has been promised a callback, and how hard we try to deliver it is a tuning decision
+// rather than an on/off switch. `max_attempts: 1` is how you ask for today's fire-once behaviour.
+
+/** Retry policy for a delivery that could not be handed to its receiver. */
+export interface DeliveryRetryConfig {
+  /**
+   * How many attempts a delivery gets before it is `dead`, counting the engine's inline first one.
+   *
+   * **Read this as a time horizon, not a count.** At the default `initialDelayMs` the delays double,
+   * so 12 attempts is 1+2+4+…+1024 ≈ **34 minutes** of trying — enough to sit out a rolling deploy
+   * or a short receiver outage with room to spare, which is what this is for. Halving it to 6 is not
+   * "half as patient": it is ~31 seconds, which does not survive a single redeploy.
+   */
+  maxAttempts?: number;
+  /**
+   * The first retry's delay, and the base the rest double from. Defaults to 1000.
+   *
+   * There is deliberately **no ceiling knob**. At any sane attempt count the doubling tops out well
+   * inside an hour (12 attempts reaches ~17 minutes), so a ceiling would be a public option that
+   * never fires — and on Redis, honouring one would mean replacing BullMQ's built-in exponential
+   * backoff with a hand-written strategy to gain nothing. If a deployment ever raises `maxAttempts`
+   * far enough for the tail to matter, that is the moment to add it.
+   */
+  initialDelayMs?: number;
+}
+
+export interface WebhookDeliveryConfig {
+  retries?: DeliveryRetryConfig;
+  /**
+   * The cap on a stored delivery body, in bytes. Defaults to 256 KiB.
+   *
+   * A delivery's payload is stored rather than re-rendered, so an unbounded one is unbounded rows in
+   * the database. Over the cap, `values` is replaced by a truncation marker **inside the body**, so a
+   * receiver is told it is looking at a truncated state rather than left to infer it.
+   */
+  maxPayloadBytes?: number;
+  /** How long a terminal delivery is kept before the sweep reclaims it, in hours. Defaults to 24. */
+  retainHours?: number;
+  /**
+   * Hostnames a delivery may be sent to. Absent means no restriction, which is today's behaviour.
+   *
+   * The `webhook` URL is caller-supplied, so it is a server-side request to a target the caller chose
+   * — and retrying it turns a one-shot SSRF probe into a repeated one. A deployment that accepts
+   * untrusted run creates should set this. It is **not** on by default: every existing deployment
+   * would start dropping its own callbacks on upgrade.
+   *
+   * A delivery to a host not on the list is recorded `dead` with the reason rather than silently
+   * skipped, so it is visible in the delivery list instead of being a callback that never arrives.
+   */
+  allowedHosts?: readonly string[];
+}
+
+export const DEFAULT_MAX_ATTEMPTS = 12;
+export const DEFAULT_INITIAL_DELAY_MS = 1_000;
+export const DEFAULT_MAX_PAYLOAD_BYTES = 256 * 1024;
+export const DEFAULT_RETAIN_HOURS = 24;
+
+/**
+ * How long a claimer holds a delivery before a peer may take it over.
+ *
+ * A constant rather than a knob: the only thing it has to clear is one POST, and the POST already has
+ * its own bound (`DEFAULT_WEBHOOK_TIMEOUT_MS`, 5s, raisable via `SKEIN_WEBHOOK_TIMEOUT_MS`). A minute
+ * leaves an order of magnitude of headroom, and the cost of getting it wrong in the tight direction is
+ * one duplicate POST — which at-least-once already permits and the delivery id already absorbs.
+ */
+export const DELIVERY_LEASE_MS = 60_000;
+
+/** How often the delivery worker looks for due deliveries. */
+export const DEFAULT_DELIVERY_POLL_INTERVAL_MS = 5_000;
+
+/** Deliveries claimed per tick, so one tick is a bounded unit of work. */
+export const DEFAULT_DELIVERY_BATCH_SIZE = 20;
+
+/**
+ * How long a delivery is invisible to the recovery sweep once a queue has taken charge of it.
+ *
+ * When a `DeliveryQueue` owns the schedule, the row's `next_attempt_at` stops meaning "try again at"
+ * and starts meaning "assume the job is lost after". So it is set to the whole remaining schedule,
+ * doubled: being too generous costs a lost job sitting a while longer, while being too tight has the
+ * sweep re-attempting a delivery the queue is merely holding — collapsing the backoff it is applying.
+ */
+export function queueSweepGraceMs(retries?: DeliveryRetryConfig): number {
+  const initial = retries?.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+  const attempts = retries?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  return initial * 2 ** attempts * 2;
+}
+
+/**
+ * Poll cadence for the recovery sweep when a queue owns the schedule.
+ *
+ * Rare on purpose: with a queue, a due row is evidence of a *lost job*, which happens only when a
+ * process died between the outbox COMMIT and the enqueue. Polling every few seconds for that would
+ * be a query per instance per tick to catch something that happens on a crash.
+ */
+export const DEFAULT_SWEEP_POLL_INTERVAL_MS = 300_000;

--- a/packages/agent-protocol/src/deliveries/delivery-config.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-config.ts
@@ -86,7 +86,26 @@ export const DEFAULT_DELIVERY_BATCH_SIZE = 20;
 export function queueSweepGraceMs(retries?: DeliveryRetryConfig): number {
   const initial = retries?.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
   const attempts = retries?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
-  return initial * 2 ** attempts * 2;
+  // Clamped, and not merely for tidiness: the schema bounds `max_attempts` only by `.positive()`, so
+  // a config with a few dozen attempts sends `2 ** attempts` past `Number.MAX_SAFE_INTEGER` and on to
+  // `Infinity` — and `new Date(Infinity).toISOString()` throws a `RangeError`, from a code path whose
+  // whole contract is that it does not throw. A day is far longer than any real schedule needs.
+  return Math.min(initial * 2 ** Math.min(attempts, 32) * 2, MAX_SWEEP_GRACE_MS);
+}
+
+/** The ceiling on {@link queueSweepGraceMs}. */
+const MAX_SWEEP_GRACE_MS = 24 * 3_600_000;
+
+/**
+ * How many attempts are left for a queue to make, given how many have already happened.
+ *
+ * Shared by the hand-off after the inline attempt and by the recovery sweep, because the sweep
+ * getting this wrong is silent: a `schedule` with no attempt budget gets BullMQ's default of one, so
+ * a recovered delivery would go `dead` on its next failure instead of finishing the schedule its
+ * configuration promised.
+ */
+export function remainingQueueAttempts(attempt: number, retries?: DeliveryRetryConfig): number {
+  return Math.max(1, (retries?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS) - attempt);
 }
 
 /**

--- a/packages/agent-protocol/src/deliveries/delivery-config.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-config.ts
@@ -60,14 +60,26 @@ export const DEFAULT_MAX_PAYLOAD_BYTES = 256 * 1024;
 export const DEFAULT_RETAIN_HOURS = 24;
 
 /**
- * How long a claimer holds a delivery before a peer may take it over.
+ * Headroom added to a claim's lease, on top of the time the batch could actually take.
  *
- * A constant rather than a knob: the only thing it has to clear is one POST, and the POST already has
- * its own bound (`DEFAULT_WEBHOOK_TIMEOUT_MS`, 5s, raisable via `SKEIN_WEBHOOK_TIMEOUT_MS`). A minute
- * leaves an order of magnitude of headroom, and the cost of getting it wrong in the tight direction is
- * one duplicate POST — which at-least-once already permits and the delivery id already absorbs.
+ * A lease has to outlive **every POST in the batch it covers**, not one of them — the polling worker
+ * attempts its claim sequentially, so with the default batch of 20 and the default 5s timeout the
+ * last row is not touched for 100 seconds. A flat minute would expire under rows 13 onward, and a
+ * peer would re-claim and re-POST them: duplicate callbacks, and an attempt budget spent twice as
+ * fast as configured. {@link deliveryLeaseMs} sizes it from the batch; this is the margin on top.
+ *
+ * Erring long is cheap — it only delays takeover after a genuine crash. Erring short duplicates
+ * callbacks in normal operation.
  */
-export const DELIVERY_LEASE_MS = 60_000;
+export const DELIVERY_LEASE_MARGIN_MS = 60_000;
+
+/**
+ * How long a claimer holds a batch of deliveries before a peer may take them over: long enough for
+ * every POST in it, plus {@link DELIVERY_LEASE_MARGIN_MS}.
+ */
+export function deliveryLeaseMs(batchSize: number, perAttemptMs: number): number {
+  return Math.max(1, batchSize) * Math.max(1, perAttemptMs) + DELIVERY_LEASE_MARGIN_MS;
+}
 
 /** How often the delivery worker looks for due deliveries. */
 export const DEFAULT_DELIVERY_POLL_INTERVAL_MS = 5_000;

--- a/packages/agent-protocol/src/deliveries/delivery-payload.test.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-payload.test.ts
@@ -1,0 +1,118 @@
+// The callback body: what is stored once, and what is supplied per attempt.
+
+import type { Delivery, DefaultValues, Run } from "@skein-js/core";
+import { describe, expect, it } from "vitest";
+
+import { buildDeliveryPayload, toDeliveryBody } from "./delivery-payload.js";
+
+const run: Run = {
+  run_id: "run-1",
+  thread_id: "thread-1",
+  assistant_id: "assistant-1",
+  status: "running",
+  metadata: { tenant: "acme" },
+  multitask_strategy: null,
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:01.000Z",
+} as Run;
+
+const built = (overrides: Partial<Parameters<typeof buildDeliveryPayload>[0]> = {}) =>
+  buildDeliveryPayload({
+    run,
+    values: { answer: 42 } as unknown as DefaultValues,
+    runStartedAt: "2026-01-01T00:00:00.000Z",
+    runEndedAt: "2026-01-01T00:00:05.000Z",
+    ...overrides,
+  });
+
+const deliveryOf = (payload: unknown, runStatus: Delivery["run_status"] = "success"): Delivery =>
+  ({ payload, run_status: runStatus }) as Delivery;
+
+describe("delivery payload", () => {
+  it("carries the run row, its final values and the run timestamps", () => {
+    const { payload, truncated } = built();
+
+    expect(truncated).toBe(false);
+    expect(payload).toMatchObject({
+      run_id: "run-1",
+      thread_id: "thread-1",
+      assistant_id: "assistant-1",
+      metadata: { tenant: "acme" },
+      values: { answer: 42 },
+      run_started_at: "2026-01-01T00:00:00.000Z",
+      run_ended_at: "2026-01-01T00:00:05.000Z",
+    });
+  });
+
+  it("stores no status of its own", () => {
+    // The run row's status at build time is `running` — the terminal one is not known until the
+    // transaction commits. Storing it here would bake in a value the driver is about to contradict.
+    expect(built().payload).not.toHaveProperty("status");
+  });
+
+  it("carries the failure message as a plain string, matching LangGraph", () => {
+    expect(built({ error: "boom" }).payload).toMatchObject({ error: "boom" });
+  });
+
+  it("omits `error` entirely for a run that did not fail", () => {
+    expect(built().payload).not.toHaveProperty("error");
+  });
+
+  it("replaces oversized values with a marker inside the body, not a header", () => {
+    // Inside the body deliberately: a header is easy to ignore, and a truncated `values` is otherwise
+    // indistinguishable from a genuinely small one. A receiver must not be able to mistake one for
+    // the other — this is the field they act on.
+    const values = { blob: "x".repeat(2_000) } as unknown as DefaultValues;
+    const { payload, truncated, bytes } = built({ values, maxPayloadBytes: 500 });
+
+    expect(truncated).toBe(true);
+    expect(bytes).toBeGreaterThan(500);
+    expect(payload["values"]).toMatchObject({ $skein_truncated: true, bytes });
+    // Everything the receiver needs to go and fetch the state for itself survives.
+    expect(payload).toMatchObject({ run_id: "run-1", thread_id: "thread-1" });
+  });
+
+  it("truncates only `values` — the rest of the row is what makes the callback actionable", () => {
+    const values = { blob: "x".repeat(2_000) } as unknown as DefaultValues;
+    const { payload } = built({ values, maxPayloadBytes: 500, error: "boom" });
+
+    expect(payload).toMatchObject({ error: "boom", run_ended_at: "2026-01-01T00:00:05.000Z" });
+  });
+
+  it("leaves a body under the cap byte-identical to an unbounded one", () => {
+    // The cap must be invisible to every deployment it does not bind on, or it is a payload change
+    // rather than a bound.
+    expect(built({ maxPayloadBytes: 1_000_000 }).payload).toEqual(built().payload);
+  });
+
+  it("measures the cap in UTF-8 bytes, not JS string length", () => {
+    // A multi-byte value that fits by `.length` and does not fit on the wire is exactly the case that
+    // would blow a column bound in production while passing every test written against `.length`.
+    const values = { text: "é".repeat(400) } as unknown as DefaultValues;
+    expect(built({ values, maxPayloadBytes: 700 }).truncated).toBe(true);
+  });
+
+  it("supplies the status from the delivery row, so the body cannot contradict the run", () => {
+    // The engine asked for `success`; a cancel won the race and the driver stamped `cancelled`. The
+    // receiver has to be told what `GET /runs/{id}` will tell them a millisecond later.
+    const body = toDeliveryBody(
+      deliveryOf(built().payload, "cancelled"),
+      "2026-01-01T00:00:06.000Z",
+    );
+
+    expect(body["status"]).toBe("cancelled");
+  });
+
+  it("stamps the send time per attempt rather than storing it", () => {
+    const delivery = deliveryOf(built().payload);
+
+    expect(toDeliveryBody(delivery, "2026-01-01T00:00:06.000Z")["webhook_sent_at"]).toBe(
+      "2026-01-01T00:00:06.000Z",
+    );
+    // A retry an hour later reports when *it* was sent — the field describes the attempt, and a
+    // stored one would tell a receiver the retry happened at the moment the run finished.
+    expect(toDeliveryBody(delivery, "2026-01-01T01:00:00.000Z")["webhook_sent_at"]).toBe(
+      "2026-01-01T01:00:00.000Z",
+    );
+  });
+});

--- a/packages/agent-protocol/src/deliveries/delivery-payload.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-payload.ts
@@ -1,0 +1,83 @@
+// The body of a run-completion callback: built once when the run settles, stored, and re-sent
+// verbatim on every retry.
+//
+// The shape is LangGraph's and does not change — this is delivery semantics, not a new payload. Two
+// fields are supplied per *attempt* rather than stored: `status`, which comes from the delivery's
+// `run_status` so the body can never contradict the run row, and `webhook_sent_at`, which describes
+// the attempt rather than the run.
+
+import type { Delivery, DefaultValues, Run } from "@skein-js/core";
+
+import { DEFAULT_MAX_PAYLOAD_BYTES } from "./delivery-config.js";
+
+/** What the truncation marker replaces `values` with, inside the signed body. */
+export interface TruncatedValues {
+  $skein_truncated: true;
+  reason: string;
+  bytes: number;
+}
+
+export interface BuildDeliveryPayloadInput {
+  run: Run;
+  values: DefaultValues;
+  runStartedAt: string;
+  runEndedAt: string;
+  /** The failure message, for a run that failed. Matches LangGraph: a plain string, not a `RunError`. */
+  error?: string;
+  maxPayloadBytes?: number;
+}
+
+export interface BuiltDeliveryPayload {
+  payload: Record<string, unknown>;
+  truncated: boolean;
+  /** The serialized size of the untruncated body, for the log line and the marker. */
+  bytes: number;
+}
+
+/**
+ * Build the stored half of a delivery body, replacing `values` with a marker when the whole thing
+ * would exceed `maxPayloadBytes`.
+ *
+ * The marker goes **inside** the body rather than in a header, so a receiver cannot be misled about
+ * having the run's whole final state — a header is easy to ignore and a truncated `values` is
+ * indistinguishable from a genuinely small one. `values` is the only field replaced because it is the
+ * only unbounded one; the rest of the row is fixed-size metadata the receiver needs to act at all.
+ */
+export function buildDeliveryPayload(input: BuildDeliveryPayloadInput): BuiltDeliveryPayload {
+  const { status: _replaced, ...run } = input.run;
+  const payload: Record<string, unknown> = {
+    ...run,
+    values: input.values,
+    run_started_at: input.runStartedAt,
+    run_ended_at: input.runEndedAt,
+    ...(input.error !== undefined ? { error: input.error } : {}),
+  };
+  const cap = input.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES;
+  const bytes = byteLength(JSON.stringify(payload));
+  if (bytes <= cap) return { payload, truncated: false, bytes };
+  const marker: TruncatedValues = {
+    $skein_truncated: true,
+    reason: `values omitted: the delivery body was ${bytes} bytes, over the ${cap}-byte cap`,
+    bytes,
+  };
+  return { payload: { ...payload, values: marker }, truncated: true, bytes };
+}
+
+/**
+ * The body to actually send on this attempt: the stored payload, plus the two fields that are a
+ * property of the attempt rather than of the run.
+ */
+export function toDeliveryBody(delivery: Delivery, sentAt: string): Record<string, unknown> {
+  return {
+    ...(delivery.payload as Record<string, unknown>),
+    // From the delivery row, never from the stored body: this is the status the finalize transaction
+    // actually committed, so a callback cannot disagree with the run a receiver reads back after it.
+    status: delivery.run_status,
+    webhook_sent_at: sentAt,
+  };
+}
+
+/** UTF-8 byte length, since the cap is on bytes over the wire rather than on JS string length. */
+function byteLength(text: string): number {
+  return typeof TextEncoder === "undefined" ? text.length : new TextEncoder().encode(text).length;
+}

--- a/packages/agent-protocol/src/deliveries/delivery-processor.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-processor.ts
@@ -1,0 +1,102 @@
+// The queue-driven attempt: what a `DeliveryQueue` consumer runs for each job.
+//
+// The division of labour is the point. **The queue decides when and whether to try again; this
+// decides what an attempt means and records what happened.** So on Redis the entire schedule —
+// delays, exponential backoff, and re-delivery of a job whose worker was killed — is BullMQ's, and
+// none of it is reimplemented here; what stays here is the part BullMQ has no opinion about: which
+// row to send, what the body is, and how the outcome is recorded so a replay and an audit still work.
+
+import type { DeliveryAttemptContext, SkeinStore } from "@skein-js/core";
+
+import { deliveryHeaders, type Logger, type WebhookDispatcher } from "../deps.js";
+
+import { queueSweepGraceMs, type WebhookDeliveryConfig } from "./delivery-config.js";
+import { toDeliveryBody } from "./delivery-payload.js";
+import { disallowedHost } from "./delivery-target.js";
+
+export interface DeliveryProcessorDeps {
+  store: Pick<SkeinStore, "deliveries">;
+  webhookDispatcher: WebhookDispatcher;
+  logger: Logger;
+  clock: () => Date;
+  webhooks?: WebhookDeliveryConfig;
+}
+
+/**
+ * Attempt the delivery named by `context`, recording the outcome.
+ *
+ * **Throws when the attempt failed and another is due** — that is how a queue is told to schedule the
+ * next one, and it is why this is a separate function from `attemptDelivery` rather than a flag on
+ * it: the engine's inline attempt must never throw (a failed callback is not a failed run), and this
+ * one must, or BullMQ would mark a job complete that nobody has delivered.
+ *
+ * Returns normally when there is nothing left to do: delivered, out of attempts, or already settled
+ * by whoever else picked it up.
+ */
+export async function processDelivery(
+  deps: DeliveryProcessorDeps,
+  context: DeliveryAttemptContext,
+): Promise<void> {
+  const deliveries = deps.store.deliveries;
+  if (!deliveries) return;
+
+  const delivery = await deliveries.get(context.deliveryId);
+  // Gone, or already settled by a peer that beat us to it — either way there is nothing to send, and
+  // throwing would ask the queue to keep retrying a delivery that is finished.
+  if (!delivery) return;
+  if (delivery.status === "delivered" || delivery.status === "dead") return;
+
+  const disallowed = disallowedHost(delivery.url, deps.webhooks?.allowedHosts);
+  if (disallowed) {
+    deps.logger.warn(`delivery ${delivery.delivery_id}: ${disallowed}`);
+    await deliveries.recordAttempt(delivery.delivery_id, { outcome: "dead", error: disallowed });
+    return;
+  }
+
+  try {
+    await deps.webhookDispatcher(
+      delivery.url,
+      toDeliveryBody(delivery, deps.clock().toISOString()),
+      {
+        deliveryId: delivery.delivery_id,
+        attempt: context.attempt,
+        headers: deliveryHeaders(delivery.delivery_id, context.attempt),
+      },
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (context.isFinalAttempt) {
+      deps.logger.error(
+        `delivery ${delivery.delivery_id} to ${delivery.url} is dead after ${context.attempt} attempt(s)`,
+        error,
+      );
+      await deliveries.recordAttempt(delivery.delivery_id, {
+        outcome: "dead",
+        error: message,
+        attempt: context.attempt,
+      });
+      // Deliberately NOT rethrown. The delivery is settled; asking the queue to retry it would
+      // contradict the row we just wrote, and on BullMQ would leave a job in the failed set whose
+      // dead letter already lives somewhere an operator can replay it from.
+      return;
+    }
+    deps.logger.warn(
+      `delivery ${delivery.delivery_id} to ${delivery.url} failed (attempt ${context.attempt}); retrying`,
+      error,
+    );
+    // The row records *that* it failed and why. When it is due again is the queue's call, so the row's
+    // `next_attempt_at` is refreshed to a lease rather than to a schedule — it is what a recovery
+    // sweep reads when a job goes missing, not what decides the retry.
+    await deliveries.recordAttempt(delivery.delivery_id, {
+      outcome: "retrying",
+      nextAttemptAt: new Date(
+        deps.clock().getTime() + queueSweepGraceMs(deps.webhooks?.retries),
+      ).toISOString(),
+      error: message,
+      attempt: context.attempt,
+    });
+    throw error;
+  }
+
+  await deliveries.recordAttempt(delivery.delivery_id, { outcome: "delivered" });
+}

--- a/packages/agent-protocol/src/deliveries/delivery-processor.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-processor.ts
@@ -10,7 +10,8 @@ import type { DeliveryAttemptContext, SkeinStore } from "@skein-js/core";
 
 import { deliveryHeaders, type Logger, type WebhookDispatcher } from "../deps.js";
 
-import { queueSweepGraceMs, type WebhookDeliveryConfig } from "./delivery-config.js";
+import { nextAttemptDelayMs } from "./backoff.js";
+import { QUEUE_SWEEP_MARGIN_MS, type WebhookDeliveryConfig } from "./delivery-config.js";
 import { toDeliveryBody } from "./delivery-payload.js";
 import { disallowedHost } from "./delivery-target.js";
 
@@ -84,13 +85,16 @@ export async function processDelivery(
       `delivery ${delivery.delivery_id} to ${delivery.url} failed (attempt ${context.attempt}); retrying`,
       error,
     );
-    // The row records *that* it failed and why. When it is due again is the queue's call, so the row's
-    // `next_attempt_at` is refreshed to a lease rather than to a schedule — it is what a recovery
-    // sweep reads when a job goes missing, not what decides the retry.
+    // The row records *that* it failed and why. When it is due again is the queue's call, so this is
+    // an estimate of the queue's own next attempt plus a margin — what the recovery sweep reads when
+    // a job goes missing, not what decides the retry. The estimate is good because our backoff was
+    // deliberately shaped to match BullMQ's.
     await deliveries.recordAttempt(delivery.delivery_id, {
       outcome: "retrying",
       nextAttemptAt: new Date(
-        deps.clock().getTime() + queueSweepGraceMs(deps.webhooks?.retries),
+        deps.clock().getTime() +
+          nextAttemptDelayMs(context.attempt, deps.webhooks?.retries) +
+          QUEUE_SWEEP_MARGIN_MS,
       ).toISOString(),
       error: message,
       attempt: context.attempt,

--- a/packages/agent-protocol/src/deliveries/delivery-processor.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-processor.ts
@@ -47,6 +47,10 @@ export async function processDelivery(
   if (!delivery) return;
   if (delivery.status === "delivered" || delivery.status === "dead") return;
 
+  // From the row, not from the job: the row is the running total, and it is the only count that
+  // survives the queue re-creating a job for this delivery. See `DeliveryAttemptContext`.
+  const attempt = delivery.attempt + 1;
+
   const disallowed = disallowedHost(delivery.url, deps.webhooks?.allowedHosts);
   if (disallowed) {
     deps.logger.warn(`delivery ${delivery.delivery_id}: ${disallowed}`);
@@ -60,21 +64,21 @@ export async function processDelivery(
       toDeliveryBody(delivery, deps.clock().toISOString()),
       {
         deliveryId: delivery.delivery_id,
-        attempt: context.attempt,
-        headers: deliveryHeaders(delivery.delivery_id, context.attempt),
+        attempt,
+        headers: deliveryHeaders(delivery.delivery_id, attempt),
       },
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     if (context.isFinalAttempt) {
       deps.logger.error(
-        `delivery ${delivery.delivery_id} to ${delivery.url} is dead after ${context.attempt} attempt(s)`,
+        `delivery ${delivery.delivery_id} to ${delivery.url} is dead after ${attempt} attempt(s)`,
         error,
       );
       await deliveries.recordAttempt(delivery.delivery_id, {
         outcome: "dead",
         error: message,
-        attempt: context.attempt,
+        attempt,
       });
       // Deliberately NOT rethrown. The delivery is settled; asking the queue to retry it would
       // contradict the row we just wrote, and on BullMQ would leave a job in the failed set whose
@@ -82,7 +86,7 @@ export async function processDelivery(
       return;
     }
     deps.logger.warn(
-      `delivery ${delivery.delivery_id} to ${delivery.url} failed (attempt ${context.attempt}); retrying`,
+      `delivery ${delivery.delivery_id} to ${delivery.url} failed (attempt ${attempt}); retrying`,
       error,
     );
     // The row records *that* it failed and why. When it is due again is the queue's call, so this is
@@ -93,11 +97,11 @@ export async function processDelivery(
       outcome: "retrying",
       nextAttemptAt: new Date(
         deps.clock().getTime() +
-          nextAttemptDelayMs(context.attempt, deps.webhooks?.retries) +
+          nextAttemptDelayMs(attempt, deps.webhooks?.retries) +
           QUEUE_SWEEP_MARGIN_MS,
       ).toISOString(),
       error: message,
-      attempt: context.attempt,
+      attempt,
     });
     throw error;
   }

--- a/packages/agent-protocol/src/deliveries/delivery-target.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-target.ts
@@ -1,0 +1,24 @@
+// Whether a callback may be sent to a URL at all.
+
+/**
+ * Why `url`'s host is not deliverable, or `undefined` when it is. An absent or empty allowlist
+ * permits everything, which is today's behaviour and stays the default.
+ *
+ * Shared by the inline attempt and the queue-driven one, so the two cannot come to disagree about
+ * what an allowlist admits — the way they would disagree is one of them accepting a host the other
+ * refuses, which reads to an operator as a callback that arrives only sometimes.
+ */
+export function disallowedHost(url: string, allowedHosts?: readonly string[]): string | undefined {
+  if (!allowedHosts || allowedHosts.length === 0) return undefined;
+  let host: string;
+  try {
+    host = new URL(url).hostname;
+  } catch {
+    return `webhook URL "${url}" is not a valid absolute URL`;
+  }
+  // Exact hostname match, deliberately: a suffix match on "example.com" would also accept
+  // "notexample.com", which is the classic way an allowlist stops being one.
+  return allowedHosts.includes(host)
+    ? undefined
+    : `webhook host "${host}" is not in skein.webhooks.allowed_hosts`;
+}

--- a/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { Logger, WebhookDispatcher } from "../deps.js";
 
+import type { DeliveryQueue, QueuedDelivery, ScheduleDeliveryOptions } from "@skein-js/core";
+
 import { DELIVERY_LEASE_MS } from "./delivery-config.js";
 import { createDeliveryWorker } from "./delivery-worker.js";
 
@@ -23,6 +25,22 @@ function collectingLogger() {
   };
   return { logger, errors };
 }
+
+/** A `DeliveryQueue` that records what it was asked to schedule instead of talking to Redis. */
+function stubQueue() {
+  const scheduled: { delivery: QueuedDelivery; options?: ScheduleDeliveryOptions }[] = [];
+  const queue: DeliveryQueue = {
+    schedule: async (delivery, options) => {
+      scheduled.push({ delivery, ...(options ? { options } : {}) });
+    },
+    consume: () => ({ close: async () => {} }),
+    durable: true,
+  };
+  return { queue, scheduled };
+}
+
+/** Due already, so a tick claims it. */
+const inPast = (): string => new Date(START.getTime() - 1_000).toISOString();
 
 /** A clock the test moves by hand. */
 function movableClock(from = START) {
@@ -197,6 +215,91 @@ describe("delivery worker", () => {
 
     expect(await worker.tickOnce()).toMatchObject({ claimed: 2 });
     expect(await worker.tickOnce()).toMatchObject({ claimed: 1 });
+  });
+
+  // Regression: the retention block used to sit after an early `return` on the queue path, so
+  // `retain_hours` was a no-op in exactly the deployments with the most rows — settled deliveries,
+  // dead ones still holding their whole payload, accumulating forever.
+  it("still reclaims settled deliveries when a queue owns the schedule", async () => {
+    const store = new MemorySkeinStore();
+    // Already past its retention when the sweep looks — `expires_at` is absolute, set at creation
+    // from `retain_hours`, so the sweep compares it against plain `now`. Subtracting the retention
+    // again here would keep every settled row for double what `retain_hours` says.
+    const settled = await seedDelivery(store, { next_attempt_at: inPast(), expires_at: inPast() });
+    await store.deliveries!.recordAttempt(settled.delivery_id, { outcome: "delivered" });
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+      logger: collectingLogger().logger,
+      clock: () => START,
+      deliveryQueue: stubQueue().queue,
+    });
+
+    expect(await worker.tickOnce()).toMatchObject({ swept: 1 });
+    expect(await store.deliveries!.get(settled.delivery_id)).toBeNull();
+  });
+
+  it("measures the retention cadence in elapsed time, not in ticks", async () => {
+    // With a queue this loop ticks every five minutes rather than every five seconds, so a tick
+    // *count* would stretch "every ten minutes" into every ten hours.
+    const store = new MemorySkeinStore();
+    const { clock, advance } = movableClock();
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+      logger: collectingLogger().logger,
+      clock,
+      deliveryQueue: stubQueue().queue,
+    });
+    const sweepExpired = vi.spyOn(store.deliveries!, "sweepExpired");
+
+    await worker.tickOnce();
+    expect(sweepExpired).toHaveBeenCalledTimes(1);
+    await worker.tickOnce();
+    expect(sweepExpired).toHaveBeenCalledTimes(1);
+    advance(700_000);
+    await worker.tickOnce();
+    expect(sweepExpired).toHaveBeenCalledTimes(2);
+  });
+
+  // Regression: the sweep used to re-schedule with no attempt budget, so BullMQ gave the job its
+  // default of one — a recovered delivery would die on its next failure instead of finishing the
+  // schedule its configuration promised, and it would look like the policy was ignored.
+  it("re-schedules a lost job with the attempts it has left, not with one", async () => {
+    const store = new MemorySkeinStore();
+    const { queue, scheduled } = stubQueue();
+    await seedDelivery(store, { next_attempt_at: inPast() });
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+      logger: collectingLogger().logger,
+      clock: () => START,
+      deliveryQueue: queue,
+      webhooks: { retries: { maxAttempts: 12 } },
+    });
+
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 1 });
+    // The claim took it to attempt 2, so ten of twelve remain.
+    expect(scheduled[0]?.options?.attempts).toBe(10);
+  });
+
+  it("hands a lost job back to the queue rather than POSTing it itself", async () => {
+    const store = new MemorySkeinStore();
+    const { queue, scheduled } = stubQueue();
+    const delivery = await seedDelivery(store, { next_attempt_at: inPast() });
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock: () => START,
+      deliveryQueue: queue,
+    });
+
+    await worker.tickOnce();
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(scheduled.map((s) => s.delivery.delivery_id)).toEqual([delivery.delivery_id]);
   });
 
   it("is a no-op on a store with no deliveries repo", async () => {

--- a/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
@@ -1,0 +1,277 @@
+// The loop that drains the outbox. Driven with `tickOnce()` and an injected clock throughout — no
+// test here waits on a timer, so none of them can be flaky for a reason that has nothing to do with
+// delivery.
+
+import type { Delivery, DeliveryCreate, RunStatus } from "@skein-js/core";
+import { MemorySkeinStore } from "@skein-js/storage-memory";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Logger, WebhookDispatcher } from "../deps.js";
+
+import { DELIVERY_LEASE_MS } from "./delivery-config.js";
+import { createDeliveryWorker } from "./delivery-worker.js";
+
+const START = new Date("2026-01-01T00:00:00.000Z");
+
+function collectingLogger() {
+  const errors: string[] = [];
+  const logger: Logger = {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: (message: string) => errors.push(message),
+  };
+  return { logger, errors };
+}
+
+/** A clock the test moves by hand. */
+function movableClock(from = START) {
+  let now = from.getTime();
+  return {
+    clock: (): Date => new Date(now),
+    advance: (ms: number): void => {
+      now += ms;
+    },
+  };
+}
+
+/** A store with one finished run that owes a callback, and the delivery it recorded. */
+async function seedDelivery(
+  store: MemorySkeinStore,
+  overrides: Partial<DeliveryCreate> = {},
+  status: RunStatus = "success",
+): Promise<Delivery> {
+  const thread = await store.threads.create();
+  const run = await store.runs.create({ thread_id: thread.thread_id, assistant_id: "a" });
+  const { delivery } = await store.runs.finalizeWithDelivery!(run.run_id, {
+    status,
+    delivery: {
+      thread_id: thread.thread_id,
+      url: "https://hooks.example.test/skein",
+      payload: { run_id: run.run_id, values: {} },
+      next_attempt_at: START.toISOString(),
+      expires_at: new Date(START.getTime() + 3_600_000).toISOString(),
+      ...overrides,
+    },
+  });
+  return delivery;
+}
+
+describe("delivery worker", () => {
+  it("claims a due delivery, sends it and marks it delivered", async () => {
+    const store = new MemorySkeinStore();
+    const delivery = await seedDelivery(store);
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock: () => START,
+    });
+
+    const summary = await worker.tickOnce();
+
+    expect(summary).toMatchObject({ claimed: 1, delivered: 1, failed: 0 });
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect((await store.deliveries!.get(delivery.delivery_id))?.status).toBe("delivered");
+  });
+
+  it("leaves a delivery that is not due yet alone", async () => {
+    const store = new MemorySkeinStore();
+    await seedDelivery(store, {
+      next_attempt_at: new Date(START.getTime() + 60_000).toISOString(),
+    });
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock: () => START,
+    });
+
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 0 });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it("retries a failed delivery on a later tick, once its backoff has elapsed", async () => {
+    const store = new MemorySkeinStore();
+    const { clock, advance } = movableClock();
+    let attempts = 0;
+    const dispatch = vi.fn<WebhookDispatcher>().mockImplementation(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error("receiver is down");
+    });
+    await seedDelivery(store);
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock,
+    });
+
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 1, delivered: 0, failed: 1 });
+    // Not due again immediately — that is the backoff doing its job.
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 0 });
+
+    advance(10_000);
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 1, delivered: 1 });
+    expect(dispatch).toHaveBeenCalledTimes(2);
+  });
+
+  // The recovery case the lease exists for: a process claimed a delivery, started the POST, and died.
+  // Nothing re-enqueues it — the row simply becomes due again when its lease lapses.
+  it("takes over a delivery whose worker died mid-POST", async () => {
+    const store = new MemorySkeinStore();
+    const { clock, advance } = movableClock();
+    // Leased exactly as the engine leases it, then abandoned: the inline attempt claimed the row,
+    // started the POST, and the process died before it could record an outcome.
+    const delivery = await seedDelivery(store, {
+      next_attempt_at: new Date(START.getTime() + DELIVERY_LEASE_MS).toISOString(),
+    });
+    expect((await store.deliveries!.get(delivery.delivery_id))?.status).toBe("delivering");
+
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock,
+    });
+
+    // While the lease holds, a peer must not touch it — or a slow POST would be sent twice.
+    advance(DELIVERY_LEASE_MS - 1_000);
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 0 });
+
+    advance(2_000);
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 1, delivered: 1 });
+  });
+
+  // Every instance runs one of these against the same store.
+  it("does not let two workers deliver the same row twice", async () => {
+    const store = new MemorySkeinStore();
+    await seedDelivery(store);
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const make = () =>
+      createDeliveryWorker({
+        store,
+        webhookDispatcher: dispatch,
+        logger: collectingLogger().logger,
+        clock: () => START,
+      });
+
+    const [first, second] = await Promise.all([make().tickOnce(), make().tickOnce()]);
+
+    expect(first.claimed + second.claimed).toBe(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps draining the batch when one receiver fails", async () => {
+    const store = new MemorySkeinStore();
+    await seedDelivery(store, { url: "https://bad.example.test/hook" });
+    await seedDelivery(store, { url: "https://good.example.test/hook" });
+    const dispatch = vi.fn<WebhookDispatcher>().mockImplementation(async (url: string) => {
+      if (url.includes("bad")) throw new Error("down");
+    });
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock: () => START,
+    });
+
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 2, delivered: 1, failed: 1 });
+  });
+
+  it("bounds one tick to the batch size", async () => {
+    const store = new MemorySkeinStore();
+    for (const _ of [0, 1, 2]) await seedDelivery(store);
+    const worker = createDeliveryWorker(
+      {
+        store,
+        webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+        logger: collectingLogger().logger,
+        clock: () => START,
+      },
+      { batchSize: 2 },
+    );
+
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 2 });
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 1 });
+  });
+
+  it("is a no-op on a store with no deliveries repo", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const worker = createDeliveryWorker({
+      store: {},
+      webhookDispatcher: dispatch,
+      logger: collectingLogger().logger,
+      clock: () => START,
+    });
+
+    expect(await worker.tickOnce()).toEqual({ claimed: 0, delivered: 0, failed: 0, swept: 0 });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  // The property that matters more than any single tick: no failure mode may silently end delivery
+  // for the life of the process.
+  it("keeps ticking after a tick throws", async () => {
+    const store = new MemorySkeinStore();
+    await seedDelivery(store);
+    const { logger, errors } = collectingLogger();
+    let calls = 0;
+    const claimDue = store.deliveries!.claimDue.bind(store.deliveries);
+    vi.spyOn(store.deliveries!, "claimDue").mockImplementation(async (query) => {
+      calls += 1;
+      if (calls === 1) throw new Error("database blip");
+      return claimDue(query);
+    });
+    const worker = createDeliveryWorker(
+      {
+        store,
+        webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+        logger,
+        clock: () => START,
+      },
+      { pollIntervalMs: 1 },
+    );
+
+    worker.start();
+    await vi.waitFor(() => expect(calls).toBeGreaterThan(1), { timeout: 2_000 });
+    await worker.stop();
+
+    expect(errors.join("\n")).toContain("delivery tick failed");
+  });
+
+  it("waits out an in-flight POST when stopping, so shutdown cannot cut one off", async () => {
+    const store = new MemorySkeinStore();
+    await seedDelivery(store);
+    let release: (() => void) | undefined;
+    let finished = false;
+    const dispatch = vi.fn<WebhookDispatcher>().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = () => {
+            finished = true;
+            resolve();
+          };
+        }),
+    );
+    const worker = createDeliveryWorker(
+      {
+        store,
+        webhookDispatcher: dispatch,
+        logger: collectingLogger().logger,
+        clock: () => START,
+      },
+      { pollIntervalMs: 1 },
+    );
+
+    worker.start();
+    await vi.waitFor(() => expect(release).toBeDefined(), { timeout: 2_000 });
+    const stopping = worker.stop();
+    release!();
+    await stopping;
+
+    expect(finished).toBe(true);
+  });
+});

--- a/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
@@ -279,8 +279,35 @@ describe("delivery worker", () => {
     });
 
     expect(await worker.tickOnce()).toMatchObject({ claimed: 1 });
-    // The claim took it to attempt 2, so ten of twelve remain.
-    expect(scheduled[0]?.options?.attempts).toBe(10);
+    // Eleven of twelve remain: only the inline attempt has been spent. The sweep reads rather than
+    // claims, so merely looking at a delivery no longer costs it an attempt.
+    expect(scheduled[0]?.options?.attempts).toBe(11);
+  });
+
+  // The property that lets the sweep run against a short horizon: looking is free. A claiming sweep
+  // would spend the budget of every delivery the queue was merely holding, so `next_attempt_at` had
+  // to be pushed hours out to keep the two apart — which is what made a lost job take hours to find.
+  it("does not spend a delivery's attempts by sweeping for it", async () => {
+    const store = new MemorySkeinStore();
+    const { queue, scheduled } = stubQueue();
+    const seeded = await seedDelivery(store, { next_attempt_at: inPast() });
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+      logger: collectingLogger().logger,
+      clock: () => START,
+      deliveryQueue: queue,
+    });
+
+    await worker.tickOnce();
+    await worker.tickOnce();
+    await worker.tickOnce();
+
+    const after = await store.deliveries!.get(seeded.delivery_id);
+    expect(after?.attempt).toBe(seeded.attempt);
+    expect(after?.next_attempt_at).toBe(seeded.next_attempt_at);
+    // Re-scheduled each pass, which is safe because `schedule` is idempotent on the delivery id.
+    expect(scheduled).toHaveLength(3);
   });
 
   it("hands a lost job back to the queue rather than POSTing it itself", async () => {

--- a/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.test.ts
@@ -3,14 +3,13 @@
 // delivery.
 
 import type { Delivery, DeliveryCreate, RunStatus } from "@skein-js/core";
+import type { DeliveryQueue, QueuedDelivery, ScheduleDeliveryOptions } from "@skein-js/core";
 import { MemorySkeinStore } from "@skein-js/storage-memory";
 import { describe, expect, it, vi } from "vitest";
 
 import type { Logger, WebhookDispatcher } from "../deps.js";
 
-import type { DeliveryQueue, QueuedDelivery, ScheduleDeliveryOptions } from "@skein-js/core";
-
-import { DELIVERY_LEASE_MS } from "./delivery-config.js";
+import { deliveryLeaseMs } from "./delivery-config.js";
 import { createDeliveryWorker } from "./delivery-worker.js";
 
 const START = new Date("2026-01-01T00:00:00.000Z");
@@ -143,8 +142,9 @@ describe("delivery worker", () => {
     const { clock, advance } = movableClock();
     // Leased exactly as the engine leases it, then abandoned: the inline attempt claimed the row,
     // started the POST, and the process died before it could record an outcome.
+    const lease = deliveryLeaseMs(1, 5_000);
     const delivery = await seedDelivery(store, {
-      next_attempt_at: new Date(START.getTime() + DELIVERY_LEASE_MS).toISOString(),
+      next_attempt_at: new Date(START.getTime() + lease).toISOString(),
     });
     expect((await store.deliveries!.get(delivery.delivery_id))?.status).toBe("delivering");
 
@@ -157,7 +157,7 @@ describe("delivery worker", () => {
     });
 
     // While the lease holds, a peer must not touch it — or a slow POST would be sent twice.
-    advance(DELIVERY_LEASE_MS - 1_000);
+    advance(lease - 1_000);
     expect(await worker.tickOnce()).toMatchObject({ claimed: 0 });
 
     advance(2_000);
@@ -198,6 +198,61 @@ describe("delivery worker", () => {
     });
 
     expect(await worker.tickOnce()).toMatchObject({ claimed: 2, delivered: 1, failed: 1 });
+  });
+
+  // Regression: the lease was a flat minute while the batch is attempted *sequentially*, so with the
+  // default batch of 20 and the default 5s timeout the tail of a batch outlived its lease — a peer
+  // re-claimed and re-POSTed rows 13 onward, duplicating callbacks and spending the attempt budget
+  // at twice the configured rate.
+  it("leases a claim for the whole batch, not for one POST", async () => {
+    const store = new MemorySkeinStore();
+    for (const _ of [0, 1, 2]) await seedDelivery(store, { next_attempt_at: inPast() });
+    const claimDue = vi.spyOn(store.deliveries!, "claimDue");
+    const worker = createDeliveryWorker(
+      {
+        store,
+        webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+        logger: collectingLogger().logger,
+        clock: () => START,
+      },
+      { batchSize: 20 },
+    );
+
+    await worker.tickOnce();
+
+    const { leaseUntil } = claimDue.mock.calls[0]![0];
+    const heldForMs = new Date(leaseUntil).getTime() - START.getTime();
+    // Longer than 20 sequential POSTs could take at the default timeout.
+    expect(heldForMs).toBeGreaterThan(20 * 5_000);
+  });
+
+  it("keeps sweeping the rest of the batch when one re-schedule fails", async () => {
+    const store = new MemorySkeinStore();
+    for (const _ of [0, 1, 2]) await seedDelivery(store, { next_attempt_at: inPast() });
+    const { logger, errors } = collectingLogger();
+    const scheduled: string[] = [];
+    let calls = 0;
+    const queue: DeliveryQueue = {
+      schedule: async (delivery) => {
+        calls += 1;
+        if (calls === 1) throw new Error("redis blip");
+        scheduled.push(delivery.delivery_id);
+      },
+      consume: () => ({ close: async () => {} }),
+      durable: true,
+    };
+    const worker = createDeliveryWorker({
+      store,
+      webhookDispatcher: vi.fn<WebhookDispatcher>().mockResolvedValue(undefined),
+      logger,
+      clock: () => START,
+      deliveryQueue: queue,
+    });
+
+    // One row lost, the other two still handed over — and the retention sweep below still runs.
+    expect(await worker.tickOnce()).toMatchObject({ claimed: 3, swept: 0 });
+    expect(scheduled).toHaveLength(2);
+    expect(errors.join("\n")).toContain("could not re-schedule");
   });
 
   it("bounds one tick to the batch size", async () => {

--- a/packages/agent-protocol/src/deliveries/delivery-worker.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.ts
@@ -25,14 +25,20 @@ import { attemptDelivery } from "./attempt-delivery.js";
 import {
   DEFAULT_DELIVERY_BATCH_SIZE,
   DEFAULT_DELIVERY_POLL_INTERVAL_MS,
-  DEFAULT_RETAIN_HOURS,
   DEFAULT_SWEEP_POLL_INTERVAL_MS,
   DELIVERY_LEASE_MS,
+  remainingQueueAttempts,
   type WebhookDeliveryConfig,
 } from "./delivery-config.js";
 
-/** How many ticks pass between retention sweeps. At the default cadence, roughly every 10 minutes. */
-const SWEEP_EVERY_TICKS = 120;
+/**
+ * How often the retention sweep runs, regardless of the poll cadence.
+ *
+ * Measured in elapsed time rather than in ticks, because the poll cadence is not fixed: with a queue
+ * this loop ticks every five minutes rather than every five seconds, so a tick *count* would stretch
+ * the same "every ten minutes" into every ten hours.
+ */
+const SWEEP_INTERVAL_MS = 600_000;
 
 export interface DeliveryWorkerDeps {
   store: Pick<SkeinStore, "deliveries">;
@@ -81,12 +87,11 @@ export function createDeliveryWorker(
     options.pollIntervalMs ??
     (deps.deliveryQueue ? DEFAULT_SWEEP_POLL_INTERVAL_MS : DEFAULT_DELIVERY_POLL_INTERVAL_MS);
   const batchSize = options.batchSize ?? DEFAULT_DELIVERY_BATCH_SIZE;
-  const retainMs = (deps.webhooks?.retainHours ?? DEFAULT_RETAIN_HOURS) * 3_600_000;
 
   let running = false;
   let timer: ReturnType<typeof setTimeout> | undefined;
   let inFlight: Promise<void> | undefined;
-  let ticks = 0;
+  let lastSweptAtMs: number | undefined;
 
   const tickOnce = async (): Promise<DeliveryTickSummary> => {
     const deliveries = deps.store.deliveries;
@@ -103,43 +108,53 @@ export function createDeliveryWorker(
     });
     summary.claimed = claimed.length;
 
-    // With a queue, this is recovery, not delivery: hand each row back and let the queue schedule it.
-    // `schedule` is idempotent on the delivery id, so re-scheduling one that is somehow still queued
-    // costs nothing — which is what makes a blind sweep safe.
     if (deps.deliveryQueue) {
+      // Recovery, not delivery: hand each row back and let the queue schedule it. `schedule` is
+      // idempotent on the delivery id, so re-scheduling one that is somehow still queued costs
+      // nothing — which is what makes a blind sweep safe.
       for (const delivery of claimed) {
         deps.logger.warn(
           `delivery ${delivery.delivery_id}: no queued job found; re-scheduling it (attempt ${delivery.attempt})`,
         );
-        await deps.deliveryQueue.schedule({ delivery_id: delivery.delivery_id });
+        await deps.deliveryQueue.schedule(
+          { delivery_id: delivery.delivery_id },
+          // The remaining budget, NOT the default. Omitting it hands BullMQ its own default of one
+          // attempt, so a recovered delivery would go dead on its next failure instead of finishing
+          // the schedule its configuration promised — and it would look like the policy was ignored.
+          { attempts: remainingQueueAttempts(delivery.attempt, deps.webhooks?.retries) },
+        );
       }
-      ticks += 1;
-      return summary;
+    } else {
+      // Sequential rather than concurrent: a backlog is usually a backlog against *one* receiver that
+      // is already struggling, and firing a batch at it in parallel is how a retry storm becomes the
+      // outage. The batch is bounded, and every instance drains its own share.
+      for (const delivery of claimed) {
+        const settled = await attemptDelivery(
+          {
+            store: { deliveries },
+            webhookDispatcher: deps.webhookDispatcher,
+            logger: deps.logger,
+            clock,
+            ...(deps.webhooks ? { webhooks: deps.webhooks } : {}),
+          },
+          delivery,
+        );
+        if (settled?.status === "delivered") summary.delivered += 1;
+        else summary.failed += 1;
+      }
     }
 
-    // Sequential rather than concurrent: a backlog is usually a backlog against *one* receiver that
-    // is already struggling, and firing a batch at it in parallel is how a retry storm becomes the
-    // outage. The batch is bounded, and every instance drains its own share.
-    for (const delivery of claimed) {
-      const settled = await attemptDelivery(
-        {
-          store: { deliveries },
-          webhookDispatcher: deps.webhookDispatcher,
-          logger: deps.logger,
-          clock,
-          ...(deps.webhooks ? { webhooks: deps.webhooks } : {}),
-        },
-        delivery,
-      );
-      if (settled?.status === "delivered") summary.delivered += 1;
-      else summary.failed += 1;
-    }
-
-    ticks += 1;
-    if (ticks % SWEEP_EVERY_TICKS === 0) {
-      summary.swept = await deliveries.sweepExpired(
-        new Date(clock().getTime() - retainMs).toISOString(),
-      );
+    // Outside the branch above, deliberately. Retention is not a property of *how* a delivery was
+    // attempted, and skipping it on the queue path would make `retain_hours` a no-op in exactly the
+    // deployments that have the most rows — settled deliveries, dead ones still holding their whole
+    // payload, accumulating forever.
+    const nowMs = clock().getTime();
+    if (lastSweptAtMs === undefined || nowMs - lastSweptAtMs >= SWEEP_INTERVAL_MS) {
+      lastSweptAtMs = nowMs;
+      // Plain `now`. A delivery's `expires_at` was already set to its creation time plus the
+      // configured retention, so subtracting the retention again here would apply it twice and keep
+      // every settled row for double what `retain_hours` says.
+      summary.swept = await deliveries.sweepExpired(new Date(nowMs).toISOString());
       if (summary.swept > 0) {
         deps.logger.info(`delivery sweep removed ${summary.swept} settled delivery/deliveries.`);
       }

--- a/packages/agent-protocol/src/deliveries/delivery-worker.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.ts
@@ -1,0 +1,193 @@
+// The delivery loop. It has two jobs, and which one it is doing depends on whether a `DeliveryQueue`
+// is wired.
+//
+// **With a queue — the production path — this is a recovery sweep, not a retry loop.** The queue owns
+// the schedule (on Redis that is BullMQ: delayed jobs, exponential backoff with jitter, and
+// re-delivery of a job whose worker was killed), so a delivery that still looks due here means its
+// *job* was lost — which happens in exactly one window, between the outbox COMMIT and the enqueue,
+// because a Redis `add()` cannot join a Postgres transaction. This sweep hands those rows back to the
+// queue. It ticks rarely, because that is a crash-only event. Same outbox-plus-sweep shape the cron
+// scheduler uses, and for the same reason.
+//
+// **Without one — development — it is the retry loop itself**, polling the outbox for rows whose
+// `next_attempt_at` has arrived and POSTing them. Correct, process-local, and lost on restart. That
+// is fine for `skein dev`; point a local Redis at it (`skein dev --queue redis`) to exercise what
+// production actually does.
+//
+// The retention sweep rides along on a slower cadence rather than living in a second loop: it is one
+// indexed DELETE, and one loop is one thing to start, one thing to stop, and one thing to get wrong.
+
+import type { DeliveryQueue, SkeinStore } from "@skein-js/core";
+
+import type { Logger, WebhookDispatcher } from "../deps.js";
+
+import { attemptDelivery } from "./attempt-delivery.js";
+import {
+  DEFAULT_DELIVERY_BATCH_SIZE,
+  DEFAULT_DELIVERY_POLL_INTERVAL_MS,
+  DEFAULT_RETAIN_HOURS,
+  DEFAULT_SWEEP_POLL_INTERVAL_MS,
+  DELIVERY_LEASE_MS,
+  type WebhookDeliveryConfig,
+} from "./delivery-config.js";
+
+/** How many ticks pass between retention sweeps. At the default cadence, roughly every 10 minutes. */
+const SWEEP_EVERY_TICKS = 120;
+
+export interface DeliveryWorkerDeps {
+  store: Pick<SkeinStore, "deliveries">;
+  webhookDispatcher: WebhookDispatcher;
+  logger: Logger;
+  /** Injected so tests can drive time; defaults to the wall clock, like every sweeper here. */
+  clock?: () => Date;
+  webhooks?: WebhookDeliveryConfig;
+  /**
+   * When present, this loop stops being the retry mechanism and becomes a **recovery sweep**: the
+   * queue owns the schedule, so a row that still looks due is evidence of a job lost to a crash
+   * between the outbox COMMIT and the enqueue. It ticks rarely and hands what it finds back to the
+   * queue rather than POSTing it.
+   */
+  deliveryQueue?: DeliveryQueue;
+}
+
+export interface DeliveryWorkerOptions {
+  /** How often to look for due deliveries, in ms. Defaults to 5000. */
+  pollIntervalMs?: number;
+  /** Deliveries claimed per tick. Defaults to 20. */
+  batchSize?: number;
+}
+
+/** What one tick did, for tests and probes. */
+export interface DeliveryTickSummary {
+  claimed: number;
+  delivered: number;
+  failed: number;
+  swept: number;
+}
+
+export interface DeliveryWorker {
+  /** Claim and attempt one batch. Exposed so tests drive the loop instead of waiting on a timer. */
+  tickOnce(): Promise<DeliveryTickSummary>;
+  start(): void;
+  stop(): Promise<void>;
+}
+
+export function createDeliveryWorker(
+  deps: DeliveryWorkerDeps,
+  options: DeliveryWorkerOptions = {},
+): DeliveryWorker {
+  const clock = deps.clock ?? ((): Date => new Date());
+  const everyMs =
+    options.pollIntervalMs ??
+    (deps.deliveryQueue ? DEFAULT_SWEEP_POLL_INTERVAL_MS : DEFAULT_DELIVERY_POLL_INTERVAL_MS);
+  const batchSize = options.batchSize ?? DEFAULT_DELIVERY_BATCH_SIZE;
+  const retainMs = (deps.webhooks?.retainHours ?? DEFAULT_RETAIN_HOURS) * 3_600_000;
+
+  let running = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let inFlight: Promise<void> | undefined;
+  let ticks = 0;
+
+  const tickOnce = async (): Promise<DeliveryTickSummary> => {
+    const deliveries = deps.store.deliveries;
+    const summary: DeliveryTickSummary = { claimed: 0, delivered: 0, failed: 0, swept: 0 };
+    if (!deliveries) return summary;
+
+    const now = clock();
+    const claimed = await deliveries.claimDue({
+      now: now.toISOString(),
+      // The claim moves each row's `next_attempt_at` to the lease, so a peer only takes it over if
+      // this process dies mid-POST — see `Delivery.next_attempt_at`.
+      leaseUntil: new Date(now.getTime() + DELIVERY_LEASE_MS).toISOString(),
+      limit: batchSize,
+    });
+    summary.claimed = claimed.length;
+
+    // With a queue, this is recovery, not delivery: hand each row back and let the queue schedule it.
+    // `schedule` is idempotent on the delivery id, so re-scheduling one that is somehow still queued
+    // costs nothing — which is what makes a blind sweep safe.
+    if (deps.deliveryQueue) {
+      for (const delivery of claimed) {
+        deps.logger.warn(
+          `delivery ${delivery.delivery_id}: no queued job found; re-scheduling it (attempt ${delivery.attempt})`,
+        );
+        await deps.deliveryQueue.schedule({ delivery_id: delivery.delivery_id });
+      }
+      ticks += 1;
+      return summary;
+    }
+
+    // Sequential rather than concurrent: a backlog is usually a backlog against *one* receiver that
+    // is already struggling, and firing a batch at it in parallel is how a retry storm becomes the
+    // outage. The batch is bounded, and every instance drains its own share.
+    for (const delivery of claimed) {
+      const settled = await attemptDelivery(
+        {
+          store: { deliveries },
+          webhookDispatcher: deps.webhookDispatcher,
+          logger: deps.logger,
+          clock,
+          ...(deps.webhooks ? { webhooks: deps.webhooks } : {}),
+        },
+        delivery,
+      );
+      if (settled?.status === "delivered") summary.delivered += 1;
+      else summary.failed += 1;
+    }
+
+    ticks += 1;
+    if (ticks % SWEEP_EVERY_TICKS === 0) {
+      summary.swept = await deliveries.sweepExpired(
+        new Date(clock().getTime() - retainMs).toISOString(),
+      );
+      if (summary.swept > 0) {
+        deps.logger.info(`delivery sweep removed ${summary.swept} settled delivery/deliveries.`);
+      }
+    }
+    return summary;
+  };
+
+  /**
+   * The loop. Its single most important property, like every other background loop here: it always
+   * schedules the next tick. The reschedule is in a `finally` and the catch never rethrows, so no
+   * failure mode — a receiver that hangs, a database blip — silently ends delivery for the life of
+   * the process.
+   */
+  const loop = async (): Promise<void> => {
+    try {
+      await tickOnce();
+    } catch (error) {
+      deps.logger.error("delivery tick failed; the worker continues.", error);
+    } finally {
+      if (running) {
+        timer = setTimeout(runLoop, everyMs);
+        timer.unref?.();
+      }
+    }
+  };
+
+  const runLoop = (): void => {
+    inFlight = loop();
+  };
+
+  return {
+    tickOnce,
+
+    start() {
+      if (running) return;
+      running = true;
+      timer = setTimeout(runLoop, everyMs);
+      timer.unref?.();
+    },
+
+    async stop() {
+      running = false;
+      if (timer) clearTimeout(timer);
+      timer = undefined;
+      // Wait out a tick already in flight, so `stop()` resolving means nothing is still POSTing.
+      // It cannot reject — `loop` swallows its own failures — so this needs no catch.
+      await inFlight;
+      inFlight = undefined;
+    },
+  };
+}

--- a/packages/agent-protocol/src/deliveries/delivery-worker.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.ts
@@ -19,14 +19,14 @@
 
 import type { DeliveryQueue, SkeinStore } from "@skein-js/core";
 
-import type { Logger, WebhookDispatcher } from "../deps.js";
+import { webhookTimeoutMs, type Logger, type WebhookDispatcher } from "../deps.js";
 
 import { attemptDelivery } from "./attempt-delivery.js";
 import {
   DEFAULT_DELIVERY_BATCH_SIZE,
   DEFAULT_DELIVERY_POLL_INTERVAL_MS,
   DEFAULT_SWEEP_POLL_INTERVAL_MS,
-  DELIVERY_LEASE_MS,
+  deliveryLeaseMs,
   remainingQueueAttempts,
   type WebhookDeliveryConfig,
 } from "./delivery-config.js";
@@ -111,20 +111,33 @@ export function createDeliveryWorker(
         deps.logger.warn(
           `delivery ${delivery.delivery_id}: no queued job found; re-scheduling it (attempt ${delivery.attempt})`,
         );
-        await deps.deliveryQueue.schedule(
-          { delivery_id: delivery.delivery_id },
-          // The remaining budget, NOT the default. Omitting it hands BullMQ its own default of one
-          // attempt, so a recovered delivery would go dead on its next failure instead of finishing
-          // the schedule its configuration promised — and it would look like the policy was ignored.
-          { attempts: remainingQueueAttempts(delivery.attempt, deps.webhooks?.retries) },
-        );
+        try {
+          await deps.deliveryQueue.schedule(
+            { delivery_id: delivery.delivery_id },
+            // The remaining budget, NOT the default. Omitting it hands BullMQ its own default of one
+            // attempt, so a recovered delivery would go dead on its next failure instead of finishing
+            // the schedule its configuration promised — and it would look like the policy was ignored.
+            { attempts: remainingQueueAttempts(delivery.attempt, deps.webhooks?.retries) },
+          );
+        } catch (error) {
+          // Per row, so one unreachable Redis does not abandon the rest of the batch — nor the
+          // retention sweep below it. The row stays due, so the next pass simply tries again.
+          deps.logger.error(
+            `delivery ${delivery.delivery_id}: could not re-schedule it; the next sweep will retry`,
+            error,
+          );
+        }
       }
     } else {
       const claimed = await deliveries.claimDue({
         now: now.toISOString(),
         // The claim moves each row's `next_attempt_at` to the lease, so a peer only takes it over if
-        // this process dies mid-POST — see `Delivery.next_attempt_at`.
-        leaseUntil: new Date(now.getTime() + DELIVERY_LEASE_MS).toISOString(),
+        // this process dies mid-POST — see `Delivery.next_attempt_at`. Sized for the *whole* batch,
+        // because the loop below is sequential: a lease covering one POST would expire under the tail
+        // of a full batch and let a peer re-send it.
+        leaseUntil: new Date(
+          now.getTime() + deliveryLeaseMs(batchSize, webhookTimeoutMs()),
+        ).toISOString(),
         limit: batchSize,
       });
       summary.claimed = claimed.length;

--- a/packages/agent-protocol/src/deliveries/delivery-worker.ts
+++ b/packages/agent-protocol/src/deliveries/delivery-worker.ts
@@ -99,20 +99,15 @@ export function createDeliveryWorker(
     if (!deliveries) return summary;
 
     const now = clock();
-    const claimed = await deliveries.claimDue({
-      now: now.toISOString(),
-      // The claim moves each row's `next_attempt_at` to the lease, so a peer only takes it over if
-      // this process dies mid-POST — see `Delivery.next_attempt_at`.
-      leaseUntil: new Date(now.getTime() + DELIVERY_LEASE_MS).toISOString(),
-      limit: batchSize,
-    });
-    summary.claimed = claimed.length;
-
     if (deps.deliveryQueue) {
-      // Recovery, not delivery: hand each row back and let the queue schedule it. `schedule` is
-      // idempotent on the delivery id, so re-scheduling one that is somehow still queued costs
-      // nothing — which is what makes a blind sweep safe.
-      for (const delivery of claimed) {
+      // **Read, do not claim.** Recovery re-schedules what it finds, and scheduling is idempotent on
+      // the delivery id — so overlapping a job the queue is merely holding costs nothing. Claiming
+      // would not be free: it increments the attempt count and shoves the lease forward, spending a
+      // budget nothing had spent. That difference is what lets `next_attempt_at` sit a minute past
+      // due instead of hours, and so what makes a lost enqueue recoverable on the next pass.
+      const due = await deliveries.listDue({ now: now.toISOString(), limit: batchSize });
+      summary.claimed = due.length;
+      for (const delivery of due) {
         deps.logger.warn(
           `delivery ${delivery.delivery_id}: no queued job found; re-scheduling it (attempt ${delivery.attempt})`,
         );
@@ -125,6 +120,14 @@ export function createDeliveryWorker(
         );
       }
     } else {
+      const claimed = await deliveries.claimDue({
+        now: now.toISOString(),
+        // The claim moves each row's `next_attempt_at` to the lease, so a peer only takes it over if
+        // this process dies mid-POST — see `Delivery.next_attempt_at`.
+        leaseUntil: new Date(now.getTime() + DELIVERY_LEASE_MS).toISOString(),
+        limit: batchSize,
+      });
+      summary.claimed = claimed.length;
       // Sequential rather than concurrent: a backlog is usually a backlog against *one* receiver that
       // is already struggling, and firing a batch at it in parallel is how a retry storm becomes the
       // outage. The batch is bounded, and every instance drains its own share.

--- a/packages/agent-protocol/src/deps.ts
+++ b/packages/agent-protocol/src/deps.ts
@@ -382,7 +382,7 @@ export const DEFAULT_WEBHOOK_TIMEOUT_MS = 5_000;
  * the variable after importing skein, and a value that only ever mattered per-request should not be
  * frozen by import order.
  */
-function webhookTimeoutMs(): number {
+export function webhookTimeoutMs(): number {
   const raw = process.env["SKEIN_WEBHOOK_TIMEOUT_MS"]?.trim();
   if (!raw) return DEFAULT_WEBHOOK_TIMEOUT_MS;
   const value = Number(raw);

--- a/packages/agent-protocol/src/deps.ts
+++ b/packages/agent-protocol/src/deps.ts
@@ -8,6 +8,7 @@ import {
   anySinkWantsRunEvents,
   combineTelemetrySinks,
   type AuthEngine,
+  type DeliveryQueue,
   type GraphSchema,
   type RunAbortChannel,
   type RunEventBus,
@@ -19,6 +20,7 @@ import {
   type TelemetrySink,
 } from "@skein-js/core";
 
+import type { WebhookDeliveryConfig } from "./deliveries/delivery-config.js";
 import type { AgentGraph, AgentGraphFactory } from "./graphs/agent-graph.js";
 import type { ThreadCheckpointer } from "./graphs/thread-checkpointer.js";
 import type { IdempotencyConfig } from "./idempotency/idempotency-config.js";
@@ -74,7 +76,47 @@ export type Clock = () => Date;
  * legitimate use, does **not** block private/loopback hosts. Deployments that accept untrusted
  * `webhook` URLs should inject a dispatcher that validates the resolved host against an allowlist.
  */
-export type WebhookDispatcher = (url: string, payload: unknown) => Promise<void>;
+export type WebhookDispatcher = (
+  url: string,
+  payload: unknown,
+  attempt?: DeliveryAttempt,
+) => Promise<void>;
+
+/**
+ * What this POST is an attempt at — supplied on every delivery the outbox drives.
+ *
+ * Optional so every existing dispatcher keeps compiling and working; a custom one that ignores it
+ * still delivers, it just leaves the receiver without a dedup key.
+ */
+export interface DeliveryAttempt {
+  /** Stable across every retry of this callback. **The receiver's dedup key.** */
+  deliveryId: string;
+  /** Which attempt this is, counting the inline first one. */
+  attempt: number;
+  /**
+   * The headers to send verbatim, already assembled.
+   *
+   * A map rather than individual fields, so a dispatcher forwards whatever skein decided to send
+   * without having to know the names — which is what lets signing land later without every custom
+   * dispatcher needing an update.
+   */
+  headers: Record<string, string>;
+}
+
+/**
+ * The headers that carry a delivery's identity to the receiver.
+ *
+ * `X-Skein-Delivery-Id` is the load-bearing one. Delivery is **at-least-once**: a POST that timed out
+ * after the receiver had already processed it is indistinguishable, from here, from one that never
+ * arrived — so it is retried, and the receiver sees it twice. Dedup on this id and that is a non-event;
+ * ignore it and skein's reliability improvement becomes the receiver's duplicate-processing bug.
+ */
+export function deliveryHeaders(deliveryId: string, attempt: number): Record<string, string> {
+  return {
+    "x-skein-delivery-id": deliveryId,
+    "x-skein-attempt": String(attempt),
+  };
+}
 
 /** A minimal structured logger. Defaults to a no-op so nothing is required. */
 export interface Logger {
@@ -225,9 +267,39 @@ export interface ProtocolDeps {
   idempotency?: IdempotencyConfig;
   /**
    * Delivers run-completion webhooks (the run's `webhook` field). Defaults to a `globalThis.fetch`
-   * POST with a JSON body; inject to customize transport/retries or to capture deliveries in tests.
+   * POST with a JSON body; inject to customize transport or to capture deliveries in tests.
+   *
+   * Note this is the transport only. Retries, dead-lettering and replay are the outbox's job now (see
+   * {@link webhooks}), because they need a write inside the run's own finalize transaction — a window
+   * that closes before any injected dispatcher runs.
    */
   webhookDispatcher?: WebhookDispatcher;
+  /**
+   * How run-completion callbacks are retried and bounded (`langgraph.json` `skein.webhooks`).
+   *
+   * Tuning only — absent means the defaults, **not** that callbacks are fire-once. `retries.max_attempts:
+   * 1` is how you ask for the pre-outbox behaviour. Whether a delivery is *durable* is a property of
+   * the store driver, not of this: a store with a `deliveries` repo records the callback in the run's
+   * finalize transaction either way.
+   *
+   * Carried on the deps rather than passed per-adapter for the same reason {@link idempotency} is:
+   * resolved once where the config is read, and every adapter forwards deps without knowing about it.
+   */
+  webhooks?: WebhookDeliveryConfig;
+  /**
+   * Where an undelivered run-completion callback waits between attempts.
+   *
+   * **This is the production path.** With it — `RedisDeliveryQueue` in a Redis deployment — the whole
+   * retry schedule is BullMQ's: delayed jobs, exponential backoff with jitter, and re-delivery of a
+   * job whose worker was killed mid-POST. Absent, skein falls back to polling the outbox for rows
+   * whose `next_attempt_at` has arrived, which is correct but process-local and lost on restart, and
+   * is the development path.
+   *
+   * Note what does *not* depend on this: whether a callback is durable at all. That comes from the
+   * store recording it in the run's finalize transaction, so a deployment with a Postgres store and
+   * no delivery queue still cannot lose a notification — it just schedules the retries less well.
+   */
+  deliveryQueue?: DeliveryQueue;
   /**
    * Optional auth engine. When set, every request is authenticated (401 on failure) and authorized
    * per resource + action (403 on deny), with ownership filters scoping reads and stamping writes.
@@ -320,7 +392,7 @@ function webhookTimeoutMs(): number {
 }
 
 /** POST the payload as JSON via the global `fetch`. The default {@link WebhookDispatcher}. */
-const fetchWebhookDispatcher: WebhookDispatcher = async (url, payload) => {
+const fetchWebhookDispatcher: WebhookDispatcher = async (url, payload, attempt) => {
   // Only http(s): reject other schemes (`file:`, `data:`, …) up front rather than hand them to fetch.
   let scheme: string;
   try {
@@ -341,7 +413,7 @@ const fetchWebhookDispatcher: WebhookDispatcher = async (url, payload) => {
   try {
     response = await send(url, {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: { "content-type": "application/json", ...attempt?.headers },
       body: JSON.stringify(payload),
       // `AbortSignal.timeout` rather than a manual controller + `setTimeout`: it needs no clearing, so
       // it cannot keep the event loop alive past a delivery that finished early.

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -87,7 +87,8 @@ export {
   DEFAULT_MAX_ATTEMPTS,
   DEFAULT_MAX_PAYLOAD_BYTES,
   DEFAULT_RETAIN_HOURS,
-  DELIVERY_LEASE_MS,
+  DELIVERY_LEASE_MARGIN_MS,
+  deliveryLeaseMs,
   QUEUE_SWEEP_MARGIN_MS,
 } from "./deliveries/delivery-config.js";
 export type { DeliveryRetryConfig, WebhookDeliveryConfig } from "./deliveries/delivery-config.js";

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -88,7 +88,7 @@ export {
   DEFAULT_MAX_PAYLOAD_BYTES,
   DEFAULT_RETAIN_HOURS,
   DELIVERY_LEASE_MS,
-  queueSweepGraceMs,
+  QUEUE_SWEEP_MARGIN_MS,
 } from "./deliveries/delivery-config.js";
 export type { DeliveryRetryConfig, WebhookDeliveryConfig } from "./deliveries/delivery-config.js";
 export { buildDeliveryPayload, toDeliveryBody } from "./deliveries/delivery-payload.js";

--- a/packages/agent-protocol/src/index.ts
+++ b/packages/agent-protocol/src/index.ts
@@ -78,6 +78,29 @@ export type {
   SearchCronsInput,
   UpdateCronInput,
 } from "./crons/cron-service.js";
+// Outbound run-completion delivery: the retry policy, and the worker that drains the outbox.
+export { attemptDelivery } from "./deliveries/attempt-delivery.js";
+export type { AttemptDeliveryDeps } from "./deliveries/attempt-delivery.js";
+export { isFinalAttempt, nextAttemptDelayMs } from "./deliveries/backoff.js";
+export {
+  DEFAULT_INITIAL_DELAY_MS,
+  DEFAULT_MAX_ATTEMPTS,
+  DEFAULT_MAX_PAYLOAD_BYTES,
+  DEFAULT_RETAIN_HOURS,
+  DELIVERY_LEASE_MS,
+  queueSweepGraceMs,
+} from "./deliveries/delivery-config.js";
+export type { DeliveryRetryConfig, WebhookDeliveryConfig } from "./deliveries/delivery-config.js";
+export { buildDeliveryPayload, toDeliveryBody } from "./deliveries/delivery-payload.js";
+export { processDelivery } from "./deliveries/delivery-processor.js";
+export type { DeliveryProcessorDeps } from "./deliveries/delivery-processor.js";
+export type { BuiltDeliveryPayload, TruncatedValues } from "./deliveries/delivery-payload.js";
+export { createDeliveryWorker } from "./deliveries/delivery-worker.js";
+export type {
+  DeliveryTickSummary,
+  DeliveryWorker,
+  DeliveryWorkerOptions,
+} from "./deliveries/delivery-worker.js";
 export { idempotencyScope, requestFingerprint } from "./idempotency/fingerprint.js";
 export type { IdempotencyConfig } from "./idempotency/idempotency-config.js";
 export { createIdempotencySweeper } from "./idempotency/idempotency-sweeper.js";
@@ -103,9 +126,11 @@ export { isRunFailureReport, RUN_FAILURE_REPORT_KIND } from "./runs/run-failure.
 export type { RunFailureReport } from "./runs/run-failure.js";
 
 // The injected dependency contract.
+export { deliveryHeaders } from "./deps.js";
 export type {
   Clock,
   CompiledGraphFactory,
+  DeliveryAttempt,
   GraphResolver,
   GraphSchemas,
   Logger,

--- a/packages/agent-protocol/src/runs/run-engine.ts
+++ b/packages/agent-protocol/src/runs/run-engine.ts
@@ -16,6 +16,7 @@ import {
   SkeinHttpError,
   toRunError,
   type DefaultValues,
+  type Delivery,
   type Metadata,
   type Run,
   type RunError,
@@ -27,6 +28,9 @@ import {
   type ThreadUpdate,
 } from "@skein-js/core";
 
+import { attemptDelivery } from "../deliveries/attempt-delivery.js";
+import { DEFAULT_RETAIN_HOURS, DELIVERY_LEASE_MS } from "../deliveries/delivery-config.js";
+import { buildDeliveryPayload } from "../deliveries/delivery-payload.js";
 import { isNoopLogger, type ResolvedDeps } from "../deps.js";
 import {
   requireAgentCapability,
@@ -275,6 +279,71 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
     );
   };
 
+  // The delivery this run's terminal status was committed alongside, when there was one to commit.
+  // Read by the `finally`, which attempts it once the run has settled.
+  let recordedDelivery: Delivery | undefined;
+
+  /**
+   * Finalize the run — and, when it owes a callback, record that callback in the *same* write.
+   *
+   * This is `finalizeRun` plus the outbox, and it replaces it at every terminal site. The two halves
+   * commit together or not at all, which is the whole point: a crash between "the run succeeded" and
+   * "someone was told" is exactly the window a webhook cannot survive today, and it sits before any
+   * injected dispatcher runs, so no caller can close it for themselves.
+   *
+   * Returns the *effective* status, exactly as `finalizeRun` does — which for a run a cancel already
+   * won is the cancel's, not the one we asked for. It reads that back off the delivery rather than
+   * recomputing it, so the row and the callback can never disagree about how the run ended.
+   */
+  const settleRun = async (
+    status: RunStatus,
+    settled: { values: DefaultValues; error?: RunError },
+  ): Promise<RunStatus> => {
+    const recordDelivery = deps.store.runs.finalizeWithDelivery;
+    // No webhook, no outbox in this driver, or a run that never executed: the pre-outbox path, which
+    // for the last case means no callback at all — matching today, where `started` gates the fire.
+    if (!started || kwargs.webhook === undefined || !deps.store.deliveries || !recordDelivery) {
+      return finalizeRun(deps, runId, status, settled.error);
+    }
+    const endedAt = deps.clock();
+    const { payload, truncated, bytes } = buildDeliveryPayload({
+      run,
+      values: settled.values,
+      runStartedAt: new Date(startedAt).toISOString(),
+      runEndedAt: endedAt.toISOString(),
+      ...(settled.error ? { error: settled.error.message } : {}),
+      ...(deps.webhooks?.maxPayloadBytes !== undefined
+        ? { maxPayloadBytes: deps.webhooks.maxPayloadBytes }
+        : {}),
+    });
+    if (truncated) {
+      // Warned on every truncation, not once per process: a receiver silently losing `values` is a
+      // shape change it cannot detect from the outside, and one log line at boot would not connect
+      // it to the run it happened to.
+      deps.logger.warn(
+        `run ${runId}: webhook payload was ${bytes} bytes; \`values\` replaced by a truncation marker`,
+      );
+    }
+    const { delivery } = await recordDelivery.call(deps.store.runs, runId, {
+      status,
+      ...(settled.error ? { error: settled.error } : {}),
+      delivery: {
+        thread_id: threadId,
+        url: kwargs.webhook,
+        payload,
+        payload_truncated: truncated,
+        // Born claimed for the inline attempt below; if this process dies before recording its
+        // outcome, the lease expires and a worker takes it over.
+        next_attempt_at: new Date(endedAt.getTime() + DELIVERY_LEASE_MS).toISOString(),
+        expires_at: new Date(
+          endedAt.getTime() + (deps.webhooks?.retainHours ?? DEFAULT_RETAIN_HOURS) * 3_600_000,
+        ).toISOString(),
+      },
+    });
+    recordedDelivery = delivery;
+    return delivery.run_status;
+  };
+
   // Arm the optional wall-clock timeout; it aborts this run's signal with reason "timeout".
   const timer =
     deps.runTimeoutMs !== undefined
@@ -384,7 +453,10 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
     if (control.signal.aborted) {
       const abortStatus = abortedStatus(control.reason.current);
       const timedOut = abortStatus === "timeout" ? RUN_TIMEOUT_ERROR : undefined;
-      const finalStatus = await finalizeRun(deps, runId, abortStatus, timedOut);
+      const finalStatus = await settleRun(abortStatus, {
+        values: {} as DefaultValues,
+        ...(timedOut ? { error: timedOut } : {}),
+      });
       if (finalStatus === "timeout")
         await mirrorThreadError(deps, threadId, RUN_TIMEOUT_ERROR.message);
       else await mirrorThreadStatus(deps, threadId, "idle");
@@ -402,7 +474,7 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
       configurable: { thread_id: threadId },
     });
     const computed = runStatusForSnapshot(snapshot);
-    const finalStatus = await finalizeRun(deps, runId, computed);
+    const finalStatus = await settleRun(computed, { values: snapshot.values as DefaultValues });
     if (finalStatus === computed) {
       await mirrorThread(deps, threadId, snapshotToThreadUpdate(snapshot, finalStatus));
     } else {
@@ -420,7 +492,10 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
   } catch (error) {
     const reason = control.reason.current;
     if (reason === "timeout") {
-      const finalStatus = await finalizeRun(deps, runId, "timeout", RUN_TIMEOUT_ERROR);
+      const finalStatus = await settleRun("timeout", {
+        values: {} as DefaultValues,
+        error: RUN_TIMEOUT_ERROR,
+      });
       if (finalStatus === "timeout")
         await mirrorThreadError(deps, threadId, RUN_TIMEOUT_ERROR.message);
       logFinished(finalStatus);
@@ -435,7 +510,7 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
     ) {
       // Displaced (interrupt/rollback) or explicitly cancelled: terminal in its own right, and the
       // thread is free again (idle). `interrupt` keeps its checkpoints; a `rollback` run drops them.
-      const finalStatus = await finalizeRun(deps, runId, abortedStatus(reason));
+      const finalStatus = await settleRun(abortedStatus(reason), { values: {} as DefaultValues });
       await mirrorThreadStatus(deps, threadId, "idle");
       logFinished(finalStatus);
       outcome = { status: finalStatus, values: {} as DefaultValues };
@@ -446,7 +521,7 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
     const wireError = toRunError(error, { includeStack: deps.exposeErrorStacks === true });
     seq += 1;
     await deps.bus.publish(runId, { seq, event: "error", data: wireError });
-    const finalStatus = await finalizeRun(deps, runId, "error", wireError);
+    const finalStatus = await settleRun("error", { values: {} as DefaultValues, error: wireError });
     if (finalStatus === "error") await mirrorThreadError(deps, threadId, wireError.message);
     // ALWAYS logged, ungated by `logRunActivity`: a run that fails silently is the whole problem
     // this reporting exists to solve. The report carries the original Error, so a console logger can
@@ -506,33 +581,76 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
     }
     // Always close the bus so every subscriber's iterator completes and emits the terminal event.
     await deps.bus.close(runId);
-    // Run-completion webhook: fire once, best-effort, only for a run that actually executed. A
-    // delivery failure is logged, never propagated — it must not fail or delay the run.
-    if (started && kwargs.webhook !== undefined) {
-      const sentAt = deps.clock().toISOString();
-      const payload = {
-        ...run,
-        status: outcome.status,
-        values: outcome.values,
-        run_started_at: new Date(startedAt).toISOString(),
-        run_ended_at: sentAt,
-        webhook_sent_at: sentAt,
-        ...(webhookErrorMessage !== undefined ? { error: webhookErrorMessage } : {}),
-      };
-      const url = kwargs.webhook;
-      const deliver = async (): Promise<void> => {
-        try {
-          await deps.webhookDispatcher(url, payload);
-        } catch (error) {
-          deps.logger.warn(`run ${runId}: webhook delivery to ${url} failed`, error);
-        }
-      };
+    // Run-completion webhook: the first attempt, made inline so a healthy receiver still hears within
+    // milliseconds rather than at the next worker tick. A failure is logged and recorded, never
+    // propagated — it must not fail or delay the run.
+    //
+    // Two shapes, and which one runs depends on the driver rather than on configuration. With an
+    // outbox, `settleRun` already committed the delivery alongside the run's status, so all that is
+    // left is to attempt it; if this process dies first, its lease expires and a worker takes over.
+    // Without one, this is the pre-outbox path verbatim: one POST, logged on failure, gone if it
+    // fails.
+    const deliver = deliverRecorded(deps, recordedDelivery) ?? deliverOnce(deps, exec, outcome);
+    if (deliver) {
       // Handed to the caller rather than awaited here, when the caller asks for it. This `finally` runs
       // inside the thread's execution lock, so awaiting a hung target here blocks every other run on
-      // the thread — and holds `payload`, which carries the run's whole final state, alive for as long
-      // as it hangs. See `startRunExecution`.
+      // the thread — and holds the payload, which carries the run's whole final state, alive for as
+      // long as it hangs. See `startRunExecution`.
       if (exec.deferWebhook) exec.deferWebhook(deliver);
       else await deliver();
     }
+  }
+
+  /** The outbox path: attempt the delivery the finalize transaction already committed. */
+  function deliverRecorded(
+    resolved: ResolvedDeps,
+    delivery: Delivery | undefined,
+  ): (() => Promise<void>) | undefined {
+    if (!delivery) return undefined;
+    return async () => {
+      await attemptDelivery(
+        {
+          store: resolved.store,
+          webhookDispatcher: resolved.webhookDispatcher,
+          logger: resolved.logger,
+          clock: resolved.clock,
+          ...(resolved.webhooks ? { webhooks: resolved.webhooks } : {}),
+          // Present in a Redis deployment: the retry after this inline attempt is BullMQ's job,
+          // not a poller's.
+          ...(resolved.deliveryQueue ? { deliveryQueue: resolved.deliveryQueue } : {}),
+        },
+        delivery,
+      );
+    };
+  }
+
+  /**
+   * The pre-outbox path, for a store with no `deliveries` repo — a third-party driver, or one
+   * deliberately left on today's semantics. One POST, swallowed on failure, never retried.
+   */
+  function deliverOnce(
+    resolved: ResolvedDeps,
+    execution: RunExecution,
+    settled: RunOutcome,
+  ): (() => Promise<void>) | undefined {
+    if (!started || execution.kwargs.webhook === undefined) return undefined;
+    const url = execution.kwargs.webhook;
+    const sentAt = resolved.clock().toISOString();
+    const payload = {
+      ...execution.run,
+      status: settled.status,
+      values: settled.values,
+      run_started_at: new Date(startedAt).toISOString(),
+      run_ended_at: sentAt,
+      webhook_sent_at: sentAt,
+      ...(webhookErrorMessage !== undefined ? { error: webhookErrorMessage } : {}),
+    };
+    return async () => {
+      try {
+        await resolved.webhookDispatcher(url, payload);
+      } catch (error) {
+        resolved.logger.warn(`run ${runId}: webhook delivery to ${url} failed`, error);
+      }
+    };
   }
 }

--- a/packages/agent-protocol/src/runs/run-engine.ts
+++ b/packages/agent-protocol/src/runs/run-engine.ts
@@ -29,9 +29,9 @@ import {
 } from "@skein-js/core";
 
 import { attemptDelivery } from "../deliveries/attempt-delivery.js";
-import { DEFAULT_RETAIN_HOURS, DELIVERY_LEASE_MS } from "../deliveries/delivery-config.js";
+import { DEFAULT_RETAIN_HOURS, deliveryLeaseMs } from "../deliveries/delivery-config.js";
 import { buildDeliveryPayload } from "../deliveries/delivery-payload.js";
-import { isNoopLogger, type ResolvedDeps } from "../deps.js";
+import { isNoopLogger, webhookTimeoutMs, type ResolvedDeps } from "../deps.js";
 import {
   requireAgentCapability,
   type AgentGraph,
@@ -302,20 +302,49 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
     const recordDelivery = deps.store.runs.finalizeWithDelivery;
     // No webhook, no outbox in this driver, or a run that never executed: the pre-outbox path, which
     // for the last case means no callback at all — matching today, where `started` gates the fire.
-    if (!started || kwargs.webhook === undefined || !deps.store.deliveries || !recordDelivery) {
+    //
+    // `recordedDelivery` is the third guard and the least obvious: this function can be reached
+    // twice. Anything after the first `settleRun` — `mirrorThread`'s write, most likely — can throw,
+    // and the catch settles the run again. The status write is idempotent (the second one finds a
+    // terminal row and leaves it), but the delivery insert is deliberately *unconditional*, so a
+    // second pass would record a second callback with a different id — two notifications for one run,
+    // one of them announcing a success that never happened, and the dedup key useless against them
+    // because the ids differ.
+    if (
+      !started ||
+      kwargs.webhook === undefined ||
+      !deps.store.deliveries ||
+      !recordDelivery ||
+      recordedDelivery !== undefined
+    ) {
       return finalizeRun(deps, runId, status, settled.error);
     }
     const endedAt = deps.clock();
-    const { payload, truncated, bytes } = buildDeliveryPayload({
-      run,
-      values: settled.values,
-      runStartedAt: new Date(startedAt).toISOString(),
-      runEndedAt: endedAt.toISOString(),
-      ...(settled.error ? { error: settled.error.message } : {}),
-      ...(deps.webhooks?.maxPayloadBytes !== undefined
-        ? { maxPayloadBytes: deps.webhooks.maxPayloadBytes }
-        : {}),
-    });
+    // Guarded because it serializes: a final state carrying a BigInt or a cycle throws here, and this
+    // now runs *before* the run's status is written. Unguarded, a graph that returned an awkward value
+    // would have its successful run recorded as `error` — the callback machinery deciding the run's
+    // outcome, which it must never do. Falling back to the plain finalize costs the callback and keeps
+    // the run honest; `buildDeliveryPayload` already substitutes a marker for the common cases.
+    let built: ReturnType<typeof buildDeliveryPayload>;
+    try {
+      built = buildDeliveryPayload({
+        run,
+        values: settled.values,
+        runStartedAt: new Date(startedAt).toISOString(),
+        runEndedAt: endedAt.toISOString(),
+        ...(settled.error ? { error: settled.error.message } : {}),
+        ...(deps.webhooks?.maxPayloadBytes !== undefined
+          ? { maxPayloadBytes: deps.webhooks.maxPayloadBytes }
+          : {}),
+      });
+    } catch (error) {
+      deps.logger.error(
+        `run ${runId}: its webhook payload could not be serialized, so no callback was recorded`,
+        error,
+      );
+      return finalizeRun(deps, runId, status, settled.error);
+    }
+    const { payload, truncated, bytes } = built;
     if (truncated) {
       // Warned on every truncation, not once per process: a receiver silently losing `values` is a
       // shape change it cannot detect from the outside, and one log line at boot would not connect
@@ -334,7 +363,10 @@ export async function executeRun(deps: ResolvedDeps, exec: RunExecution): Promis
         payload_truncated: truncated,
         // Born claimed for the inline attempt below; if this process dies before recording its
         // outcome, the lease expires and a worker takes it over.
-        next_attempt_at: new Date(endedAt.getTime() + DELIVERY_LEASE_MS).toISOString(),
+        // A batch of one: the engine makes exactly one inline attempt before handing over.
+        next_attempt_at: new Date(
+          endedAt.getTime() + deliveryLeaseMs(1, webhookTimeoutMs()),
+        ).toISOString(),
         expires_at: new Date(
           endedAt.getTime() + (deps.webhooks?.retainHours ?? DEFAULT_RETAIN_HOURS) * 3_600_000,
         ).toISOString(),

--- a/packages/agent-protocol/src/runs/run-input.test.ts
+++ b/packages/agent-protocol/src/runs/run-input.test.ts
@@ -1,7 +1,7 @@
 import { isCommand } from "@langchain/langgraph";
+import { describe, expect, it } from "vitest";
 
 import { isAgentCommand } from "../graphs/agent-command.js";
-import { describe, expect, it } from "vitest";
 
 import {
   normalizeModes,

--- a/packages/agent-protocol/src/runs/webhook.test.ts
+++ b/packages/agent-protocol/src/runs/webhook.test.ts
@@ -210,6 +210,127 @@ describe("webhook delivery and the thread lock", () => {
   });
 });
 
+// The outbox: on a driver with a `deliveries` repo, the callback is recorded in the *same write* as
+// the run's terminal status, and the POST above is merely the first attempt at a row that already
+// exists. That is the whole difference between "we tried to tell you" and "we will tell you".
+describe("the run-completion outbox", () => {
+  it("records the delivery alongside the run's terminal status", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { deps, run, control, kwargs } = await seed({ webhookDispatcher: dispatch }, "echo", {
+      input: { value: "hi" },
+      webhook: "https://example.test/hook",
+    });
+
+    await executeRun(deps, { run, kwargs, control });
+
+    const [delivery] = await deps.store.deliveries!.listByRun(run.run_id);
+    expect(delivery).toMatchObject({
+      run_id: run.run_id,
+      thread_id: run.thread_id,
+      url: "https://example.test/hook",
+      run_status: "success",
+      // Delivered on the inline attempt, so the payload is already cleared.
+      status: "delivered",
+      payload: null,
+    });
+  });
+
+  it("keeps a failed delivery for the worker instead of losing it", async () => {
+    // Today this is where a notification disappears: the POST fails, the failure is logged, and
+    // nothing remembers a callback was owed.
+    const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("receiver is down"));
+    const { deps, run, control, kwargs } = await seed({ webhookDispatcher: dispatch }, "echo", {
+      input: { value: "hi" },
+      webhook: "https://example.test/hook",
+    });
+
+    const outcome = await executeRun(deps, { run, kwargs, control });
+
+    expect(outcome.status).toBe("success");
+    const [delivery] = await deps.store.deliveries!.listByRun(run.run_id);
+    expect(delivery).toMatchObject({ status: "pending", last_error: "receiver is down" });
+    // The payload survives, because a retry has to have something to send.
+    expect(delivery?.payload).toMatchObject({ run_id: run.run_id });
+  });
+
+  // The race the whole `run_status` column exists for. A cancel lands while the graph is finishing;
+  // it owns the run's status, so the callback has to report *its* verdict — a receiver that reads the
+  // run back a millisecond later must not find it saying something else.
+  it("stamps the delivery with the winner's status when a cancel beat the engine", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { deps, run, control, kwargs } = await seed({ webhookDispatcher: dispatch }, "echo", {
+      input: { value: "hi" },
+      webhook: "https://example.test/hook",
+    });
+    // Stand in for `cancelRun`, which writes the terminal status with a bare `setStatus` and
+    // deliberately races the engine: the moment the run goes `running`, the cancel lands on top.
+    // Hooked on that write rather than left to timing, so the race is the same on every run of this
+    // suite.
+    const setStatus = deps.store.runs.setStatus.bind(deps.store.runs);
+    vi.spyOn(deps.store.runs, "setStatus").mockImplementation(async (runId, status, error) => {
+      const written = await setStatus(runId, status, error);
+      if (status === "running") await setStatus(runId, "cancelled");
+      return written;
+    });
+
+    await executeRun(deps, { run, kwargs, control });
+
+    const [delivery] = await deps.store.deliveries!.listByRun(run.run_id);
+    expect(delivery?.run_status).toBe("cancelled");
+    expect((await deps.store.runs.get(run.run_id))?.status).toBe("cancelled");
+    // And the body the receiver got agrees with the row, rather than with what the engine intended.
+    expect(dispatch.mock.calls[0]![1]).toMatchObject({ status: "cancelled" });
+  });
+
+  it("records nothing for a run that carries no webhook", async () => {
+    const { deps, run, control, kwargs } = await seed({}, "echo", { input: { value: "hi" } });
+
+    await executeRun(deps, { run, kwargs, control });
+
+    expect(await deps.store.deliveries!.listByRun(run.run_id)).toEqual([]);
+  });
+
+  it("falls back to one best-effort POST on a store with no deliveries repo", async () => {
+    // A third-party driver that has not adopted the outbox keeps working, with today's semantics.
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { deps, run, control, kwargs } = await seed({ webhookDispatcher: dispatch }, "echo", {
+      input: { value: "hi" },
+      webhook: "https://example.test/hook",
+    });
+    const withoutOutbox = {
+      ...deps,
+      store: Object.assign(Object.create(Object.getPrototypeOf(deps.store) as object), deps.store, {
+        deliveries: undefined,
+        runs: { ...deps.store.runs, finalizeWithDelivery: undefined },
+      }),
+    } as typeof deps;
+
+    const outcome = await executeRun(withoutOutbox, { run, kwargs, control });
+
+    expect(outcome.status).toBe("success");
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch.mock.calls[0]![1]).toMatchObject({ status: "success", values: {} });
+    expect(await deps.store.deliveries!.listByRun(run.run_id)).toEqual([]);
+  });
+
+  it("truncates an oversized payload inside the body, and says so on the row", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("down"));
+    const { deps, run, control, kwargs } = await seed(
+      { webhookDispatcher: dispatch, webhooks: { maxPayloadBytes: 200 } },
+      "echo",
+      { input: { value: "x".repeat(1_000) }, webhook: "https://example.test/hook" },
+    );
+
+    await executeRun(deps, { run, kwargs, control });
+
+    const [delivery] = await deps.store.deliveries!.listByRun(run.run_id);
+    expect(delivery?.payload_truncated).toBe(true);
+    expect((delivery?.payload as { values: unknown }).values).toMatchObject({
+      $skein_truncated: true,
+    });
+  });
+});
+
 // The default dispatcher's timeout. Untested, this is the fragile part of the change: the friendly
 // message depends on undici surfacing `AbortSignal.timeout`'s reason as a `TimeoutError`, and if a
 // future runtime wraps it differently the degradation is silent — a raw DOMException in a warn line.

--- a/packages/agent-protocol/src/runs/webhook.test.ts
+++ b/packages/agent-protocol/src/runs/webhook.test.ts
@@ -313,6 +313,69 @@ describe("the run-completion outbox", () => {
     expect(await deps.store.deliveries!.listByRun(run.run_id)).toEqual([]);
   });
 
+  // Regression: `settleRun` can be reached twice — anything after the first one (the thread mirror's
+  // write, most likely) can throw, and the catch settles the run again. The status write is
+  // idempotent, but the delivery insert is deliberately unconditional, so the second pass recorded a
+  // *second* callback with a different id: two notifications for one run, one announcing a success
+  // that never happened, and `X-Skein-Delivery-Id` powerless against them because the ids differ.
+  it("records exactly one delivery even when settling the run twice", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { deps, run, control, kwargs } = await seed({ webhookDispatcher: dispatch }, "echo", {
+      input: { value: "hi" },
+      webhook: "https://example.test/hook",
+    });
+    // Blow up after the run has been finalized, exactly where the thread mirror writes.
+    const update = deps.store.threads.update.bind(deps.store.threads);
+    let mirrored = false;
+    vi.spyOn(deps.store.threads, "update").mockImplementation(async (threadId, patch) => {
+      if (!mirrored) {
+        mirrored = true;
+        throw new Error("thread mirror failed");
+      }
+      return update(threadId, patch);
+    });
+
+    await executeRun(deps, { run, kwargs, control });
+
+    const deliveries = await deps.store.deliveries!.listByRun(run.run_id);
+    expect(deliveries).toHaveLength(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression: building the payload serializes it, and that now happens *before* the run's status is
+  // written. A final state carrying a BigInt threw from there, so a successful run was recorded as
+  // `error` — the callback machinery deciding the run's outcome, which it must never do.
+  it("does not fail a run whose final state cannot be serialized", async () => {
+    const dispatch = vi.fn<WebhookDispatcher>().mockResolvedValue(undefined);
+    const { deps, run, control, kwargs } = await seed({ webhookDispatcher: dispatch }, "echo", {
+      input: { value: "hi" },
+      webhook: "https://example.test/hook",
+    });
+    // Thrown only for the delivery body, so the store's own serialization is unaffected — this
+    // stands in for a final state carrying a BigInt or a cycle.
+    const stringify = JSON.stringify.bind(JSON);
+    const spy = vi.spyOn(JSON, "stringify").mockImplementation((value, ...rest) => {
+      if (value !== null && typeof value === "object" && "run_started_at" in value) {
+        throw new TypeError("Do not know how to serialize a BigInt");
+      }
+      return stringify(value, ...(rest as []));
+    });
+
+    let outcome;
+    try {
+      outcome = await executeRun(deps, { run, kwargs, control });
+    } finally {
+      // Restored here rather than in an `afterEach`: a global stub on `JSON.stringify` that outlives
+      // this case breaks every test after it, in ways that look nothing like this one.
+      spy.mockRestore();
+    }
+
+    // The run is what it was. Losing the callback is the acceptable half of this trade.
+    expect(outcome.status).toBe("success");
+    expect((await deps.store.runs.get(run.run_id))?.status).toBe("success");
+    expect(await deps.store.deliveries!.listByRun(run.run_id)).toEqual([]);
+  });
+
   it("truncates an oversized payload inside the body, and says so on the row", async () => {
     const dispatch = vi.fn<WebhookDispatcher>().mockRejectedValue(new Error("down"));
     const { deps, run, control, kwargs } = await seed(

--- a/packages/agent-protocol/src/runtime.ts
+++ b/packages/agent-protocol/src/runtime.ts
@@ -4,6 +4,7 @@
 // it, and the scheduler creates runs through the same store the worker drains.
 
 import { SkeinHttpError } from "@skein-js/core";
+import type { DeliveryConsumer } from "@skein-js/core";
 
 import { createAuthScopedStore } from "./auth/auth-scoped-store.js";
 import { resolveAuthContext } from "./auth/authenticate-request.js";
@@ -16,6 +17,12 @@ import {
   type CronScheduler,
   type CronSchedulerOptions,
 } from "./crons/cron-scheduler.js";
+import { processDelivery } from "./deliveries/delivery-processor.js";
+import {
+  createDeliveryWorker,
+  type DeliveryWorker,
+  type DeliveryWorkerOptions,
+} from "./deliveries/delivery-worker.js";
 import type { ProtocolDeps } from "./deps.js";
 import {
   createIdempotencySweeper,
@@ -47,6 +54,12 @@ export interface ProtocolRuntimeOptions {
    * whether — a caller can send `Idempotency-Key` whatever the server configured.
    */
   idempotencySweep?: IdempotencySweeperOptions;
+  /**
+   * Tuning for the outbound delivery worker (poll cadence, batch size). Like the sweeps above, this
+   * is how often and how much, not whether: a run that carries a `webhook` owes a callback whatever
+   * the server configured.
+   */
+  deliveryWorker?: DeliveryWorkerOptions;
 }
 
 /** The wired engine: the service, the handler table, the background worker, and the cron scheduler. */
@@ -87,6 +100,15 @@ export interface ProtocolRuntime {
    * whose sweeper never ticked is carrying dead rows, not answering wrongly.
    */
   idempotencySweeper: IdempotencySweeper;
+  /**
+   * The loop that retries outbound run-completion callbacks, and takes over the ones whose process
+   * died mid-POST.
+   *
+   * Always present, like the sweepers — and a no-op on a store with no `deliveries` repo, where the
+   * engine falls back to a single best-effort POST. Started and stopped alongside the worker; exposed
+   * for a host that wants to drive `tickOnce()` itself.
+   */
+  deliveryWorker: DeliveryWorker;
 }
 
 /**
@@ -206,6 +228,56 @@ export function createProtocolRuntime(
         : {}),
   );
 
+  // Always built, for the same reason the sweepers are: a run carrying a `webhook` owes a callback
+  // whether or not the server configured a retry policy, and the delivery the engine records has to
+  // be drained by something. Cheap when unused — one indexed read matching nothing per tick, on an
+  // unref'd timer — and a complete no-op on a driver with no `deliveries` repo.
+  const deliveryWorker = createDeliveryWorker(
+    {
+      store: context.deps.store,
+      webhookDispatcher: context.deps.webhookDispatcher,
+      logger: context.deps.logger,
+      clock: context.deps.clock,
+      ...(deps.webhooks ? { webhooks: deps.webhooks } : {}),
+      ...(deps.deliveryQueue ? { deliveryQueue: deps.deliveryQueue } : {}),
+    },
+    options.deliveryWorker ?? {},
+  );
+
+  // Said once at startup, not discovered later. A deployment whose *store* survives a restart but
+  // whose delivery *schedule* does not will lose every in-flight retry on each deploy — and the
+  // symptom is a callback that silently stops being retried, which is precisely what this feature
+  // exists to make impossible. Same posture, and the same reason, as the cron scheduler's warning
+  // about a non-durable store.
+  if (deps.store.durable === true && deps.deliveryQueue?.durable !== true) {
+    context.deps.logger.warn(
+      "run-completion callbacks are scheduled in memory: a retry still waiting when this process " +
+        "exits is lost. Configure Redis (REDIS_URI) so BullMQ owns the retry schedule.",
+    );
+  }
+
+  // The queue's consumer, when there is a queue. This is what actually retries a callback in
+  // production; `deliveryWorker` above is only the sweep that recovers jobs a crash lost.
+  //
+  // Opened in `start()`, NOT here. Consuming from construction would mean merely *building* a runtime
+  // starts pulling other instances' work — so a process that assembled one to inspect its handler
+  // table, or a test that never started it, would quietly take deliveries and, on teardown, abandon
+  // them. Everything else here hangs off `worker.start()`/`worker.stop()`; so does this.
+  let deliveryConsumer: DeliveryConsumer | undefined;
+  const consumeDeliveries = (): DeliveryConsumer | undefined =>
+    deps.deliveryQueue?.consume((attempt) =>
+      processDelivery(
+        {
+          store: context.deps.store,
+          webhookDispatcher: context.deps.webhookDispatcher,
+          logger: context.deps.logger,
+          clock: context.deps.clock,
+          ...(deps.webhooks ? { webhooks: deps.webhooks } : {}),
+        },
+        attempt,
+      ),
+    );
+
   // Both the scheduler and the abort-channel subscription hang off the worker's lifecycle rather
   // than off methods of their own. Five adapters plus the CLI already call `worker.start()` and
   // `worker.stop()`, and none of them will learn a second pair — so a host that forgets cannot leave
@@ -228,6 +300,7 @@ export function createProtocolRuntime(
     scheduler,
     threadTtlSweeper,
     idempotencySweeper,
+    deliveryWorker,
     worker: {
       get inFlightRunCount() {
         return worker.inFlightRunCount;
@@ -237,6 +310,8 @@ export function createProtocolRuntime(
         scheduler.start();
         threadTtlSweeper.start();
         idempotencySweeper.start();
+        deliveryWorker.start();
+        deliveryConsumer ??= consumeDeliveries();
       },
       stop: async () => {
         await scheduler.stop();
@@ -247,6 +322,15 @@ export function createProtocolRuntime(
         // stops with the other sweepers so a torn-down store never has a loop still writing into it.
         await idempotencySweeper.stop();
         await worker.stop();
+        // AFTER the worker, deliberately: draining runs are still recording deliveries, and stopping
+        // the delivery worker first would leave that last batch sitting until the next process boots.
+        // Its own `stop()` waits out an in-flight POST, so this cannot cut one off mid-flight.
+        await deliveryWorker.stop();
+        // After the sweep, and after the run worker: a draining run may still be recording a delivery
+        // and handing it over, and closing the consumer first would leave that last callback sitting
+        // until another instance picks it up.
+        await deliveryConsumer?.close();
+        deliveryConsumer = undefined;
         await subscription?.close();
       },
     },

--- a/packages/config/src/langgraph-json.test.ts
+++ b/packages/config/src/langgraph-json.test.ts
@@ -37,6 +37,40 @@ describe("parseLanggraphJson", () => {
     ).toThrow(SkeinConfigError);
   });
 
+  it("accepts a webhook delivery policy", () => {
+    const config = parseLanggraphJson({
+      graphs: { agent: "./a.ts:graph" },
+      skein: {
+        webhooks: {
+          retries: { max_attempts: 6, initial_delay_ms: 500 },
+          allowed_hosts: ["hooks.example.com"],
+        },
+      },
+    });
+    expect(config.skein?.webhooks).toEqual({
+      retries: { max_attempts: 6, initial_delay_ms: 500 },
+      allowed_hosts: ["hooks.example.com"],
+    });
+  });
+
+  it("rejects a zero attempt count rather than letting it become an off switch", () => {
+    // `.positive()`, not a bare number: `0` survives the engine's `?? default` fallback (`??` only
+    // falls through on nullish), so it would accept a `webhook`, record the delivery, and never send
+    // it — a callback silently owed forever. Same trap `skein.idempotency` documents.
+    expect(() =>
+      parseLanggraphJson({
+        graphs: { agent: "./a.ts:graph" },
+        skein: { webhooks: { retries: { max_attempts: 0 } } },
+      }),
+    ).toThrow(SkeinConfigError);
+    expect(() =>
+      parseLanggraphJson({
+        graphs: { agent: "./a.ts:graph" },
+        skein: { webhooks: { retries: { initial_delay_ms: 0 } } },
+      }),
+    ).toThrow(SkeinConfigError);
+  });
+
   it("passes unknown keys through unchanged (so an existing config round-trips)", () => {
     const config = parseLanggraphJson({ graphs: {}, future_field: 42 }) as Record<string, unknown>;
     expect(config["future_field"]).toBe(42);

--- a/packages/config/src/langgraph-json.ts
+++ b/packages/config/src/langgraph-json.ts
@@ -115,6 +115,61 @@ const idempotencySchema = z
 /** The validated `skein.idempotency` block. */
 export type IdempotencyJsonConfig = z.infer<typeof idempotencySchema>;
 
+/**
+ * `skein.webhooks` — how run-completion callbacks are retried and bounded.
+ *
+ * A skein original under the reserved namespace, for the reason {@link idempotencySchema} gives.
+ * LangGraph's `webhook` field is a bare URL with no delivery policy at all, so there is nothing here
+ * to stay compatible with — only the payload shape, which this does not touch.
+ *
+ * Tuning only. Omitting the block does **not** make callbacks fire-once: a run that carries a
+ * `webhook` owes a callback, and how hard the server tries is a deployment decision rather than
+ * permission to try at all. `retries.max_attempts: 1` is how you ask for one shot.
+ */
+const webhooksSchema = z
+  .object({
+    retries: z
+      .object({
+        // `.positive()` throughout, for the reason `idempotencySchema` spells out: a `0` survives the
+        // `?? default` fallback and silently becomes an off switch. `max_attempts: 0` would give every
+        // delivery zero attempts — a `webhook` field accepted, recorded, and never sent, which is
+        // worse than the fire-once behaviour this block exists to improve on. `initial_delay_ms: 0`
+        // collapses the backoff into an unbounded retry storm against a receiver that is already down.
+        /**
+         * Attempts before a delivery is dead, counting the inline first one (default 12).
+         *
+         * A **time horizon, not a count**: the delays double, so 12 ≈ 34 minutes and 6 ≈ 31 seconds.
+         */
+        max_attempts: z.number().positive().optional(),
+        /**
+         * The first retry's delay, and the base the rest double from, in ms (default 1000).
+         *
+         * There is no ceiling knob: the doubling tops out inside an hour at any sane attempt count,
+         * and on Redis the schedule is BullMQ's own exponential backoff rather than ours.
+         */
+        initial_delay_ms: z.number().positive().optional(),
+      })
+      .passthrough()
+      .optional(),
+    /** Cap on a stored delivery body, in bytes (default 262144). Over it, `values` is truncated. */
+    max_payload_bytes: z.number().positive().optional(),
+    /** How long a settled delivery is kept before the sweep reclaims it, in hours (default 24). */
+    retain_hours: z.number().positive().optional(),
+    /**
+     * Hostnames a callback may be sent to. Absent means no restriction, which is today's behaviour —
+     * turning it on by default would make every existing deployment start dropping its own callbacks.
+     *
+     * Set it if you accept run creates from untrusted callers: `webhook` is a caller-supplied URL, so
+     * it is a server-side request to a target they chose, and retrying it turns a one-shot SSRF probe
+     * into a repeated one.
+     */
+    allowed_hosts: z.array(z.string().trim().min(1)).optional(),
+  })
+  .passthrough();
+
+/** The validated `skein.webhooks` block. */
+export type WebhooksJsonConfig = z.infer<typeof webhooksSchema>;
+
 const runtimeSchema = z
   .object({
     /** Native runtime used by the built production artifact. */
@@ -137,6 +192,7 @@ export const langgraphJsonSchema = z
       .object({
         runtime: runtimeSchema.optional(),
         idempotency: idempotencySchema.optional(),
+        webhooks: webhooksSchema.optional(),
       })
       .passthrough()
       .optional(),
@@ -173,11 +229,17 @@ export const langgraphJsonSchema = z
       .object({
         cors: z.object({}).passthrough().optional(),
         // Declared as `unknown`, not `boolean`. This block used to be opaque
-        // (`z.object({}).passthrough()`), so a config carrying `"disable_runs": "${DISABLE_RUNS}"` — env
-        // substitution, which this loader supports — or a hand-written `"true"` string loaded fine.
+        // (`z.object({}).passthrough()`), so a config carrying a hand-written `"true"` string — or a
+        // `"${DISABLE_RUNS}"` written by someone expecting env substitution — loaded fine.
         // Typing these as booleans would turn those into a *startup failure*, since `parseLanggraphJson`
         // throws on any violation. Only a literal `true` disables a group; that decision lives in
         // `disabledRoutesFromHttpConfig`, which is also where the string/number cases are handled.
+        //
+        // To be clear about the `${…}` case, since this comment previously claimed the opposite:
+        // **skein does not expand `${VAR}` anywhere in `langgraph.json`.** `resolve-env.ts` reads the
+        // `env` block into a map and the CLI applies it to `process.env`; nothing reads it back out
+        // into the parsed config. A `"${VAR}"` here is the literal string, which for a boolean flag is
+        // merely ignored — but would be catastrophic for a secret, so no `skein.*` block takes one.
         disable_assistants: z.unknown().optional(),
         disable_threads: z.unknown().optional(),
         disable_runs: z.unknown().optional(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export type {
   DueCron,
   DueCronsQuery,
   DueDeliveriesQuery,
+  DueDeliveryScan,
   FinalizedRun,
   IdempotencyClaim,
   IdempotencyClaimResult,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -134,6 +134,17 @@ export type {
   RunAbortSubscription,
 } from "./queue/run-abort-channel.js";
 
+// Outbound delivery scheduling contract — where a run-completion callback waits between attempts.
+export type {
+  DeliveryAttemptContext,
+  DeliveryConsumer,
+  DeliveryConsumerOptions,
+  DeliveryProcessor,
+  DeliveryQueue,
+  QueuedDelivery,
+  ScheduleDeliveryOptions,
+} from "./queue/delivery-queue.js";
+
 // Run queue + streaming pub/sub contract.
 export type {
   EnqueueOptions,

--- a/packages/core/src/queue/delivery-queue.ts
+++ b/packages/core/src/queue/delivery-queue.ts
@@ -38,11 +38,12 @@ export interface ScheduleDeliveryOptions {
 export interface DeliveryAttemptContext {
   deliveryId: string;
   /**
-   * Which attempt this is, counting the caller's inline one as the first. Recorded on the delivery
-   * row, so the admin list and the `X-Skein-Attempt` header report what actually happened rather than
-   * the count the row happened to be created with.
+   * Deliberately no attempt number. A queue cannot supply one that survives its own recovery: a job
+   * re-created by the sweep starts counting from zero again, so a count derived from the job would
+   * walk *backwards* — moving the row's `attempt` and the `X-Skein-Attempt` header down, and letting
+   * the total run past `max_attempts`. The processor takes it from the delivery row instead, which is
+   * the running total and which it reads regardless.
    */
-  attempt: number;
   /**
    * True when the queue will **not** schedule another attempt if this one fails, so the processor
    * knows to record the delivery `dead` rather than `retrying`.

--- a/packages/core/src/queue/delivery-queue.ts
+++ b/packages/core/src/queue/delivery-queue.ts
@@ -1,0 +1,98 @@
+// Where an outbound run-completion callback waits between attempts.
+//
+// Separate from {@link RunQueue} rather than a widening of it, because the two carry different work
+// with different retry semantics: a run is executed **once** and its failure is recorded on its own
+// row (`attempts: 1`, `removeOnFail: true` in the Redis driver), while a delivery is retried on a
+// schedule and its failure is a reason to try again. Folding them together would mean one set of job
+// options serving both, and the run queue's options are already load-bearing for the cron sweep.
+//
+// **The queue owns the retry schedule; the store owns the truth.** The delivery row is written in the
+// same transaction as the run's terminal status and holds the payload, the attempt count and the
+// outcome — so a lost job is recoverable and a replay has something to resend. What the queue decides
+// is only *when* the next attempt happens, and whether there is one. That split is what lets the
+// Redis driver hand the whole schedule to BullMQ (delayed jobs, exponential backoff, stalled-job
+// recovery) without the durability guarantee depending on Redis.
+
+/** A delivery handed to the queue. Identity only: the payload is read from the store at send time. */
+export interface QueuedDelivery {
+  delivery_id: string;
+}
+
+/** Per-schedule options. */
+export interface ScheduleDeliveryOptions {
+  /**
+   * Hold the delivery back this long before its first attempt on the queue.
+   *
+   * The run engine attempts a delivery inline before ever scheduling it, so this is the backoff after
+   * that first failure. A driver that cannot delay durably must say so — see {@link DeliveryQueue}.
+   */
+  delayMs?: number;
+  /**
+   * How many attempts the queue itself will make before giving up, on top of the caller's inline one.
+   * A driver that owns the retry schedule uses this to size it.
+   */
+  attempts?: number;
+}
+
+/** What the processor is told about the attempt it is being asked to make. */
+export interface DeliveryAttemptContext {
+  deliveryId: string;
+  /**
+   * Which attempt this is, counting the caller's inline one as the first. Recorded on the delivery
+   * row, so the admin list and the `X-Skein-Attempt` header report what actually happened rather than
+   * the count the row happened to be created with.
+   */
+  attempt: number;
+  /**
+   * True when the queue will **not** schedule another attempt if this one fails, so the processor
+   * knows to record the delivery `dead` rather than `retrying`.
+   *
+   * Supplied by the queue rather than derived by the processor, because the queue is what decides:
+   * a driver backed by BullMQ knows from the job's own attempt budget, and a processor recomputing
+   * that from configuration would disagree with it the moment the two drifted.
+   */
+  isFinalAttempt: boolean;
+}
+
+/**
+ * Makes one attempt. **Throws to tell the queue the attempt failed** and another should be scheduled;
+ * returns normally when the delivery is settled and needs no further attempts — delivered, dead, or
+ * gone.
+ */
+export type DeliveryProcessor = (context: DeliveryAttemptContext) => Promise<void>;
+
+export interface DeliveryConsumerOptions {
+  /** Deliveries attempted at once. Defaults to the driver's own modest bound. */
+  concurrency?: number;
+}
+
+export interface DeliveryConsumer {
+  close(force?: boolean): Promise<void>;
+}
+
+/**
+ * The scheduler behind outbound deliveries.
+ *
+ * Optional throughout skein: without one, the delivery worker falls back to polling the store for
+ * rows whose `next_attempt_at` has arrived, which is correct but neither push-based nor durable
+ * across a restart. **That fallback is the development path.** A production deployment wires the
+ * Redis driver, where the whole schedule — delays, exponential backoff, and re-delivery of a job
+ * whose worker died — is BullMQ's rather than ours.
+ */
+export interface DeliveryQueue {
+  /**
+   * Schedule a delivery. Idempotent on `delivery_id`: scheduling one that is already queued must not
+   * produce a second attempt, so a recovery sweep can re-schedule blindly — the same property
+   * {@link RunQueue.enqueue} has, and for the same reason.
+   */
+  schedule(delivery: QueuedDelivery, options?: ScheduleDeliveryOptions): Promise<void>;
+  consume(process: DeliveryProcessor, options?: DeliveryConsumerOptions): DeliveryConsumer;
+  /**
+   * Whether a scheduled delivery survives a process restart.
+   *
+   * Read to warn, exactly as {@link SkeinStore.durable} is: a deployment whose store is durable but
+   * whose delivery schedule is not will lose in-flight retries on every deploy, and a callback that
+   * silently stops being retried is worse than one that was never promised.
+   */
+  readonly durable?: boolean;
+}

--- a/packages/core/src/store/deliveries.ts
+++ b/packages/core/src/store/deliveries.ts
@@ -116,6 +116,13 @@ export interface DeliveryListQuery extends Pagination {
   status?: DeliveryStatus;
 }
 
+/** What a non-mutating due scan asks for. */
+export interface DueDeliveryScan {
+  /** The application's clock. A delivery is due when its `next_attempt_at` is at or before this. */
+  now: string;
+  limit?: number;
+}
+
 /** A worker's claim on due deliveries. */
 export interface DueDeliveriesQuery {
   /** The application's clock. A row is due when its `next_attempt_at` is at or before this. */
@@ -131,8 +138,16 @@ export interface DueDeliveriesQuery {
  */
 export type DeliveryAttemptResult =
   | { outcome: "delivered" }
-  | { outcome: "retrying"; nextAttemptAt: string; error: string }
-  | { outcome: "dead"; error: string };
+  | { outcome: "retrying"; nextAttemptAt: string; error: string; attempt?: number }
+  | { outcome: "dead"; error: string; attempt?: number };
+
+/**
+ * `attempt` above exists because {@link DeliveryRepo.claimDue} is not the only thing that makes an
+ * attempt. When a {@link DeliveryQueue} owns the schedule, the queue hands work to a processor
+ * directly and nothing claims — so the count has to come from whoever knows it, or a delivery tried a
+ * dozen times would still read `attempt: 1` in the admin list and in the `X-Skein-Attempt` header.
+ * Omitted, the row's own count stands, which is what the polling path wants.
+ */
 
 /**
  * Outbound run-completion callbacks awaiting delivery — the transactional outbox behind the
@@ -165,7 +180,23 @@ export interface DeliveryRepo {
    */
   claimDue(query: DueDeliveriesQuery): Promise<Delivery[]>;
   /**
-   * Record how the current attempt ended; `null` for an unknown delivery.
+   * Deliveries due at `query.now`, **without claiming them** — soonest first, same predicate as
+   * {@link claimDue}.
+   *
+   * The read half of the scan-then-act split {@link CronRepo.listDue} makes, and it exists for a
+   * sharper reason than symmetry. When a {@link DeliveryQueue} owns the schedule, the recovery sweep
+   * is looking for deliveries whose *job* was lost, and its remedy is to re-schedule them — an
+   * idempotent operation. Using {@link claimDue} for that would be actively wrong: claiming mutates,
+   * so every pass over a delivery the queue is merely holding would increment its attempt count and
+   * shove its lease forward, exhausting a budget nothing had spent.
+   *
+   * Because this does not mutate, the sweep is free to run against a short horizon — which is what
+   * turns "a lost job is recovered in a couple of hours" into "within one sweep interval".
+   */
+  listDue(query: DueDeliveryScan): Promise<Delivery[]>;
+  /**
+   * Record how the current attempt ended; `null` for an unknown delivery. A `result.attempt` overwrites
+   * the row's count; without one the row keeps its own.
    *
    * `delivered` **clears the payload** — that is what makes steady-state storage (in-flight ×
    * payload cap) rather than (every delivery ever × payload cap), and it is why {@link retryNow}

--- a/packages/runtime-redis/src/index.ts
+++ b/packages/runtime-redis/src/index.ts
@@ -3,6 +3,7 @@
 // the run engine/worker use them unchanged. See docs/runs-and-redis.md and docs/streaming.md.
 
 export { RedisRunQueue, type RedisRunQueueOptions } from "./redis-run-queue.js";
+export { RedisDeliveryQueue, type RedisDeliveryQueueOptions } from "./redis-delivery-queue.js";
 export {
   RedisRunEventBus,
   type RedisClientFactory,

--- a/packages/runtime-redis/src/redis-delivery-queue.ts
+++ b/packages/runtime-redis/src/redis-delivery-queue.ts
@@ -47,18 +47,9 @@ export interface RedisDeliveryQueueOptions {
   queueName?: string;
   /** The base delay doubled between attempts, in ms. Default 1000. */
   initialDelayMs?: number;
-  /**
-   * How long a settled job is kept in Redis, in seconds.
-   *
-   * Short on purpose, and it costs nothing: the delivery row outlives the job and is what the admin
-   * list and the replay endpoint read. A retained BullMQ job would be a *second* dead-letter store an
-   * operator has to know about, which is exactly the split this design avoids.
-   */
-  keepSettledSeconds?: number;
 }
 
 const DEFAULT_INITIAL_DELAY_MS = 1_000;
-const DEFAULT_KEEP_SETTLED_SECONDS = 3_600;
 
 /** BullMQ-backed {@link DeliveryQueue}. Owns its connections; call {@link dispose} to release them. */
 export class RedisDeliveryQueue implements DeliveryQueue {
@@ -66,14 +57,12 @@ export class RedisDeliveryQueue implements DeliveryQueue {
   readonly #url: string;
   readonly #queueName: string;
   readonly #initialDelayMs: number;
-  readonly #keepSettledSeconds: number;
   readonly #workers = new Set<Worker<QueuedDelivery>>();
 
   constructor(url: string, options: RedisDeliveryQueueOptions = {}) {
     this.#url = url;
     this.#queueName = options.queueName ?? "skein-deliveries";
     this.#initialDelayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
-    this.#keepSettledSeconds = options.keepSettledSeconds ?? DEFAULT_KEEP_SETTLED_SECONDS;
     this.#queue = new Queue<QueuedDelivery>(this.#queueName, { connection: { url } });
   }
 
@@ -100,11 +89,16 @@ export class RedisDeliveryQueue implements DeliveryQueue {
         // BullMQ's own exponential backoff, jitter included. This line is the reason there is no
         // retry scheduler in this file: delays, doubling and randomization are all upstream's.
         backoff: { type: "exponential", delay: this.#initialDelayMs, jitter: JITTER_FRACTION },
-        // Settled jobs are dropped promptly. The delivery row is the record — and, as with the run
-        // queue, a retained job would hold its `jobId` and make that delivery permanently
-        // un-re-schedulable, so a replay would silently do nothing.
-        removeOnComplete: { age: this.#keepSettledSeconds },
-        removeOnFail: { age: this.#keepSettledSeconds },
+        // Dropped the instant they settle — NOT retained for a window. A retained job keeps holding
+        // its `jobId`, and BullMQ answers `add` with the existing job rather than queueing anything,
+        // so every later `schedule` for that delivery is a silent no-op: the recovery sweep would
+        // report a rescue on every pass while the callback stayed stuck forever. The run queue takes
+        // exactly this posture, for exactly this reason.
+        //
+        // Nothing is lost by dropping them. The delivery row outlives the job and is what the admin
+        // list, the replay endpoint and the dead letter all read.
+        removeOnComplete: true,
+        removeOnFail: true,
       },
     );
   }
@@ -115,9 +109,6 @@ export class RedisDeliveryQueue implements DeliveryQueue {
       async (job) =>
         process({
           deliveryId: job.data.delivery_id,
-          // +1 for the engine's inline attempt, which happened before this job existed, and +1 again
-          // because `attemptsMade` counts attempts *finished*.
-          attempt: job.attemptsMade + 2,
           // `attemptsMade` counts attempts *finished*, so during the run of attempt n it reads n-1.
           // Asked of the job rather than recomputed from configuration, so the processor and the
           // queue cannot disagree about which attempt is the last — the way they would disagree is a

--- a/packages/runtime-redis/src/redis-delivery-queue.ts
+++ b/packages/runtime-redis/src/redis-delivery-queue.ts
@@ -1,0 +1,147 @@
+// Redis-backed delivery scheduling on BullMQ — the production path for outbound run-completion
+// callbacks.
+//
+// **Nothing here reimplements retrying.** The whole schedule is BullMQ's: `attempts` bounds how many
+// times a callback is tried, its built-in exponential backoff (jitter included) spaces them out,
+// delayed jobs hold each one until it is due, and stalled-job recovery re-delivers a job whose
+// worker was killed mid-POST.
+// That last one is why this needs no lease of its own — BullMQ already has one, and it is better
+// tested than anything we would write.
+//
+// What is *not* BullMQ's is the durability guarantee. The delivery row is written in the same
+// transaction as the run's terminal status (see `RunRepo.finalizeWithDelivery`), because a Redis
+// `add()` cannot join a Postgres transaction — so the row is the source of truth for the payload, the
+// outcome and the replay, and a job is only ever the schedule. A crash between the COMMIT and the
+// `add()` therefore loses a *job*, not a notification: the delivery worker's slow sweep finds the row
+// and schedules it. That is the same outbox-plus-sweep shape the cron scheduler already uses.
+
+import type {
+  DeliveryConsumer,
+  DeliveryConsumerOptions,
+  DeliveryProcessor,
+  DeliveryQueue,
+  QueuedDelivery,
+  ScheduleDeliveryOptions,
+} from "@skein-js/core";
+import { Queue, Worker } from "bullmq";
+
+import { settleBullConnection } from "./redis-connection.js";
+
+const JOB_NAME = "delivery";
+
+/**
+ * How much of each delay BullMQ randomizes away.
+ *
+ * Its built-in `exponential` strategy takes this directly, so there is no custom strategy here and no
+ * backoff arithmetic of our own — which was the whole point of putting the schedule on BullMQ. The
+ * in-memory fallback copies this shape so a retry policy means one thing on both drivers.
+ *
+ * Jitter is not decoration: without it every callback that failed against one receiver during one
+ * outage retries in lockstep forever after, so the receiver comes back up into a synchronized herd of
+ * exactly the requests that just overwhelmed it.
+ */
+const JITTER_FRACTION = 0.2;
+
+export interface RedisDeliveryQueueOptions {
+  /** BullMQ queue name; also namespaces the Redis keys. Must not contain `:`. Default `"skein-deliveries"`. */
+  queueName?: string;
+  /** The base delay doubled between attempts, in ms. Default 1000. */
+  initialDelayMs?: number;
+  /**
+   * How long a settled job is kept in Redis, in seconds.
+   *
+   * Short on purpose, and it costs nothing: the delivery row outlives the job and is what the admin
+   * list and the replay endpoint read. A retained BullMQ job would be a *second* dead-letter store an
+   * operator has to know about, which is exactly the split this design avoids.
+   */
+  keepSettledSeconds?: number;
+}
+
+const DEFAULT_INITIAL_DELAY_MS = 1_000;
+const DEFAULT_KEEP_SETTLED_SECONDS = 3_600;
+
+/** BullMQ-backed {@link DeliveryQueue}. Owns its connections; call {@link dispose} to release them. */
+export class RedisDeliveryQueue implements DeliveryQueue {
+  readonly #queue: Queue<QueuedDelivery>;
+  readonly #url: string;
+  readonly #queueName: string;
+  readonly #initialDelayMs: number;
+  readonly #keepSettledSeconds: number;
+  readonly #workers = new Set<Worker<QueuedDelivery>>();
+
+  constructor(url: string, options: RedisDeliveryQueueOptions = {}) {
+    this.#url = url;
+    this.#queueName = options.queueName ?? "skein-deliveries";
+    this.#initialDelayMs = options.initialDelayMs ?? DEFAULT_INITIAL_DELAY_MS;
+    this.#keepSettledSeconds = options.keepSettledSeconds ?? DEFAULT_KEEP_SETTLED_SECONDS;
+    this.#queue = new Queue<QueuedDelivery>(this.#queueName, { connection: { url } });
+  }
+
+  /** A scheduled delivery survives a restart: BullMQ holds it in Redis, not in a process timer. */
+  get durable(): boolean {
+    return true;
+  }
+
+  async schedule(delivery: QueuedDelivery, options: ScheduleDeliveryOptions = {}): Promise<void> {
+    await this.#queue.add(
+      JOB_NAME,
+      { delivery_id: delivery.delivery_id },
+      {
+        ...(options.delayMs !== undefined && options.delayMs > 0 ? { delay: options.delayMs } : {}),
+        // Keyed on the delivery id, which makes scheduling **idempotent**: BullMQ refuses a second
+        // job with an id already in the queue. That is what lets the recovery sweep re-schedule a
+        // delivery it cannot prove was queued, without risking a second callback.
+        //
+        // Prefixed rather than passed bare, for the reason the run queue documents: BullMQ rejects a
+        // custom id that parses as an integer, and skein does not constrain id formats.
+        jobId: `${JOB_NAME}-${delivery.delivery_id}`,
+        // The attempt budget the queue owns, on top of the engine's inline first attempt.
+        ...(options.attempts !== undefined ? { attempts: Math.max(1, options.attempts) } : {}),
+        // BullMQ's own exponential backoff, jitter included. This line is the reason there is no
+        // retry scheduler in this file: delays, doubling and randomization are all upstream's.
+        backoff: { type: "exponential", delay: this.#initialDelayMs, jitter: JITTER_FRACTION },
+        // Settled jobs are dropped promptly. The delivery row is the record — and, as with the run
+        // queue, a retained job would hold its `jobId` and make that delivery permanently
+        // un-re-schedulable, so a replay would silently do nothing.
+        removeOnComplete: { age: this.#keepSettledSeconds },
+        removeOnFail: { age: this.#keepSettledSeconds },
+      },
+    );
+  }
+
+  consume(process: DeliveryProcessor, options: DeliveryConsumerOptions = {}): DeliveryConsumer {
+    const worker = new Worker<QueuedDelivery>(
+      this.#queueName,
+      async (job) =>
+        process({
+          deliveryId: job.data.delivery_id,
+          // +1 for the engine's inline attempt, which happened before this job existed, and +1 again
+          // because `attemptsMade` counts attempts *finished*.
+          attempt: job.attemptsMade + 2,
+          // `attemptsMade` counts attempts *finished*, so during the run of attempt n it reads n-1.
+          // Asked of the job rather than recomputed from configuration, so the processor and the
+          // queue cannot disagree about which attempt is the last — the way they would disagree is a
+          // delivery marked dead while BullMQ keeps retrying it, or the reverse.
+          isFinalAttempt: job.attemptsMade + 1 >= (job.opts.attempts ?? 1),
+        }),
+      {
+        connection: { url: this.#url },
+        concurrency: options.concurrency ?? 5,
+      },
+    );
+    this.#workers.add(worker);
+    return {
+      close: async (force = false) => {
+        this.#workers.delete(worker);
+        await worker.close(force);
+        if (!force) await settleBullConnection(worker);
+      },
+    };
+  }
+
+  /** Release the queue's own connection. Consumers are closed through their {@link DeliveryConsumer}. */
+  async dispose(): Promise<void> {
+    await this.#queue.close();
+    await settleBullConnection(this.#queue);
+  }
+}

--- a/packages/runtime/src/build-runtime.ts
+++ b/packages/runtime/src/build-runtime.ts
@@ -11,7 +11,6 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { MemorySaver } from "@langchain/langgraph";
-import { cloneLangGraphCheckpoint, langGraphResolver, SkeinBaseStore } from "@skein-js/langgraph";
 import { withStoreItems } from "@skein-js/agent-protocol";
 import type { GraphResolver, GraphSchemas, ProtocolDeps } from "@skein-js/agent-protocol";
 import {
@@ -23,10 +22,12 @@ import {
 } from "@skein-js/config";
 import type { GraphSchemas as ConfigGraphSchemas } from "@skein-js/config";
 import type { TelemetrySink } from "@skein-js/core";
+import { cloneLangGraphCheckpoint, langGraphResolver, SkeinBaseStore } from "@skein-js/langgraph";
 import {
   corsFromHttpConfig,
   loadReloadableInMemoryRuntime,
   resolveIdempotency,
+  resolveWebhooks,
   resolveStoreTtl,
   resolveThreadTtl,
   resolveMaxPageSize,
@@ -285,6 +286,10 @@ export async function buildRuntime(options: BuildRuntimeOptions): Promise<SkeinR
     // this through `loadReloadableInMemoryRuntime`, which reads the same block from its own config —
     // both paths, or the knob would work under `skein start` and do nothing under `skein dev`.
     const idempotency = resolveIdempotency(first.config.skein?.idempotency);
+    // Delivery policy from langgraph.json `skein.webhooks`. Absence is *defaults*, not fire-once —
+    // a run carrying a `webhook` owes a callback either way. The memory branch above resolves this
+    // itself, for the reason that comment gives.
+    const webhooks = resolveWebhooks(first.config.skein?.webhooks);
     // `requireEnv` is evaluated eagerly (before any connect), so a missing POSTGRES_URI still throws
     // before a pool is opened. The Postgres store + saver assembly (shared connection tuning, ordered
     // teardown) lives in `connectPostgresStore` — reused by `embedPostgresGraphs`.
@@ -353,9 +358,20 @@ export async function buildRuntime(options: BuildRuntimeOptions): Promise<SkeinR
       queue: runQueue,
       bus,
       abortChannel,
+      deliveryQueue,
     } = queue === "redis"
-      ? connectRedisQueue({ url: requireEnv("REDIS_URI", "redis"), disposers })
-      : { queue: new MemoryRunQueue(), bus: new MemoryRunEventBus(resolveMemoryBusLimits()) };
+      ? connectRedisQueue({
+          url: requireEnv("REDIS_URI", "redis"),
+          disposers,
+          ...(webhooks ? { webhooks } : {}),
+        })
+      : {
+          queue: new MemoryRunQueue(),
+          bus: new MemoryRunEventBus(resolveMemoryBusLimits()),
+          // No delivery queue on the memory path: the delivery worker polls the outbox instead. That
+          // is the development shape — correct, but the schedule dies with the process.
+          deliveryQueue: undefined,
+        };
 
     // Telemetry sinks from the `telemetry` block plus environment auto-detection. Left off the deps
     // entirely when nothing is configured, so the engine's `telemetryEnabled` guards stay false.
@@ -384,6 +400,10 @@ export async function buildRuntime(options: BuildRuntimeOptions): Promise<SkeinR
       ...(threadTtl ? { threadTtl } : {}),
       // Unlike `threadTtl`, absence is *defaults*, not *off* — `Idempotency-Key` is honoured either way.
       ...(idempotency ? { idempotency } : {}),
+      ...(webhooks ? { webhooks } : {}),
+      // Present only with Redis. Without it the delivery worker polls the outbox instead — correct,
+      // but the schedule dies with the process, which is why `createProtocolRuntime` warns.
+      ...(deliveryQueue ? { deliveryQueue } : {}),
       ...(serverVersion !== undefined ? { serverVersion } : {}),
       auth: await loadAuthEngine(first.config.auth, {
         configDir: first.configDir,

--- a/packages/runtime/src/drivers.ts
+++ b/packages/runtime/src/drivers.ts
@@ -7,10 +7,11 @@
 // See build-runtime.ts and embed-postgres-graphs.ts.
 
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
-import type { ProtocolDeps } from "@skein-js/agent-protocol";
+import type { ProtocolDeps, WebhookDeliveryConfig } from "@skein-js/agent-protocol";
 import {
   RedisRunAbortChannel,
   RedisRunEventBus,
+  RedisDeliveryQueue,
   RedisRunQueue,
   type RedisRunEventBusOptions,
 } from "@skein-js/redis";
@@ -287,10 +288,22 @@ export function redisEventBusOptions(): RedisRunEventBusOptions {
 export function connectRedisQueue(args: {
   url: string;
   disposers: Disposer[];
-}): Pick<ProtocolDeps, "queue" | "bus" | "abortChannel"> {
+  /** The retry policy, so the queue's own backoff is sized from `skein.webhooks` rather than guessed. */
+  webhooks?: WebhookDeliveryConfig;
+}): Pick<ProtocolDeps, "queue" | "bus" | "abortChannel" | "deliveryQueue"> {
   const { url, disposers } = args;
   const queue = new RedisRunQueue(url);
   disposers.push(() => queue.dispose());
+  // Comes along with Redis rather than behind a flag, for the same reason the abort channel does:
+  // Redis is what makes a deployment production-shaped, and a production deployment whose webhook
+  // retries live in a process timer loses them on every deploy. With this, the retry schedule is
+  // BullMQ's — delayed jobs, exponential backoff with jitter, stalled-job recovery.
+  const deliveryQueue = new RedisDeliveryQueue(url, {
+    ...(args.webhooks?.retries?.initialDelayMs !== undefined
+      ? { initialDelayMs: args.webhooks.retries.initialDelayMs }
+      : {}),
+  });
+  disposers.push(() => deliveryQueue.dispose());
   const bus = new RedisRunEventBus(url, redisEventBusOptions());
   disposers.push(() => bus.dispose());
   const abortChannel = new RedisRunAbortChannel(url, {
@@ -299,7 +312,7 @@ export function connectRedisQueue(args: {
     onError: (error) => console.warn("skein: run abort channel error", error),
   });
   disposers.push(() => abortChannel.dispose());
-  return { queue, bus, abortChannel };
+  return { queue, bus, abortChannel, deliveryQueue };
 }
 
 /**

--- a/packages/runtime/src/embed-postgres-graphs.ts
+++ b/packages/runtime/src/embed-postgres-graphs.ts
@@ -9,9 +9,9 @@
 // docs/embedding.md.
 
 import { MemorySaver } from "@langchain/langgraph";
-import { cloneLangGraphCheckpoint, SkeinBaseStore } from "@skein-js/langgraph";
 import { withStoreItems } from "@skein-js/agent-protocol";
 import type { GraphResolver, ProtocolDeps } from "@skein-js/agent-protocol";
+import { cloneLangGraphCheckpoint, SkeinBaseStore } from "@skein-js/langgraph";
 import {
   normalizeEmbeddableGraphs,
   resolveMaxPageSize,
@@ -84,8 +84,13 @@ export interface EmbedPostgresGraphsOptions {
   maxPageSize?: number;
   /**
    * Replace or add any NON-driver dep — `auth`, `logger`, `clock`, `logRunActivity`, `runTimeoutMs`,
-   * `webhookDispatcher`. The drivers (`store`/`queue`/`bus`/`checkpointer`) and `graphs` are owned by
-   * this helper and excluded, so a stray override can't void the durable wiring or the graph source.
+   * `webhookDispatcher`, `webhooks`. The drivers (`store`/`queue`/`bus`/`checkpointer`) and `graphs`
+   * are owned by this helper and excluded, so a stray override can't void the durable wiring or the
+   * graph source.
+   *
+   * This helper reads no `langgraph.json`, so `webhooks` (the delivery retry policy) arrives here
+   * rather than from a config block. Outbound callbacks are durable either way: that comes from the
+   * Postgres store's `deliveries` repo, which this helper always wires.
    */
   overrides?: Omit<Partial<ProtocolDeps>, "graphs" | "store" | "queue" | "bus" | "checkpointer">;
 }
@@ -202,9 +207,20 @@ export async function embedPostgresGraphs(
     // No Redis means the in-memory bus in production. Bound it from the environment rather than
     // leaving it at the constructor defaults — this is the path a Postgres-only deployment runs on,
     // and it is the one that has to survive weeks of uptime.
-    const { queue, bus } = redisUrl
-      ? connectRedisQueue({ url: redisUrl, disposers })
-      : { queue: new MemoryRunQueue(), bus: new MemoryRunEventBus(resolveMemoryBusLimits()) };
+    const { queue, bus, deliveryQueue } = redisUrl
+      ? connectRedisQueue({
+          url: redisUrl,
+          disposers,
+          ...(options.overrides?.webhooks ? { webhooks: options.overrides.webhooks } : {}),
+        })
+      : {
+          queue: new MemoryRunQueue(),
+          bus: new MemoryRunEventBus(resolveMemoryBusLimits()),
+          // Without Redis there is nowhere durable to hold a retry, so the delivery worker polls the
+          // outbox instead. Callbacks are still never *lost* — the row is written in the run's
+          // transaction — but a retry still waiting when the process exits does not survive it.
+          deliveryQueue: undefined,
+        };
 
     const deps: ProtocolDeps = {
       store,
@@ -220,6 +236,7 @@ export async function embedPostgresGraphs(
       // Carried so the runtime's sweeper picks up the configured cadence; the sweeper itself runs
       // either way, because a per-thread `ttl` needs collecting with or without a default.
       ...(options.threadTtl ? { threadTtl: options.threadTtl } : {}),
+      ...(deliveryQueue ? { deliveryQueue } : {}),
       ...options.overrides, // spread LAST, mirroring embedInMemoryGraphs
     };
     return { deps, dispose };

--- a/packages/runtime/src/webhook-delivery-redis.integration.test.ts
+++ b/packages/runtime/src/webhook-delivery-redis.integration.test.ts
@@ -253,9 +253,12 @@ describe("durable outbound delivery — Postgres outbox, BullMQ schedule", () =>
     disposed = true;
 
     // A healthy instance sweeps: the row is due, no job exists, so it is handed back to the queue.
-    // `next_attempt_at` is pushed a long way out when a queue owns the schedule, so the sweep is
-    // driven with a clock past that grace rather than by waiting for it.
-    const dueAt = new Date(Date.now() + 6 * 3_600_000);
+    //
+    // Two minutes, not two hours. When a queue owns the schedule the row's `next_attempt_at` is the
+    // queue's estimated next attempt plus a one-minute margin — short, because the sweep *reads*
+    // rather than claims, so overlapping a job the queue is merely holding costs nothing. This is the
+    // assertion that a lost enqueue is recovered on the next sweep pass rather than hours later.
+    const dueAt = new Date(Date.now() + 120_000);
     const rescuer = await startInstance(queueName, { clock: () => dueAt });
     await rescuer.runtime.deliveryWorker.tickOnce();
 

--- a/packages/runtime/src/webhook-delivery-redis.integration.test.ts
+++ b/packages/runtime/src/webhook-delivery-redis.integration.test.ts
@@ -1,0 +1,268 @@
+// The production delivery path: Postgres for the outbox, BullMQ for the schedule.
+//
+// These cases exist to prove the division of labour actually holds at runtime, because it is the
+// thing most easily broken by a later edit:
+//
+//   - the row is written in the run's transaction, so a callback is never *lost*;
+//   - the retry is a BullMQ job, so it survives the process that created it;
+//   - a job lost in the one window that exists (a crash between the outbox COMMIT and the enqueue)
+//     is recovered by the sweep rather than by luck.
+//
+// Nothing here drives a clock forward by hand: BullMQ owns the timing, so the delays are real. They
+// are kept small by configuring a short `initialDelayMs` rather than by waiting out the defaults.
+
+import { createServer, type Server } from "node:http";
+
+import { MessagesAnnotation, StateGraph } from "@langchain/langgraph";
+import { createProtocolRuntime, type ProtocolDeps } from "@skein-js/agent-protocol";
+import { RedisDeliveryQueue } from "@skein-js/redis";
+import { startPostgres, startRedis, type StartedResource } from "@skein-js/test-support";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { embedPostgresGraphs } from "./embed-postgres-graphs.js";
+
+function buildGraph() {
+  return new StateGraph(MessagesAnnotation)
+    .addNode("noop", () => ({ messages: [] }))
+    .addEdge("__start__", "noop")
+    .addEdge("noop", "__end__")
+    .compile();
+}
+
+let pg: StartedResource;
+let redis: StartedResource;
+
+beforeAll(async () => {
+  [pg, redis] = await Promise.all([startPostgres(), startRedis()]);
+}, 180_000);
+
+afterAll(async () => {
+  await pg?.stop();
+  await redis?.stop();
+});
+
+const cleanup: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0)) await dispose();
+});
+
+/** A receiver that refuses the first `failFirst` requests, then accepts. */
+async function startReceiver(failFirst = 0) {
+  const received: Record<string, unknown>[] = [];
+  let refused = 0;
+  const server: Server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => (body += String(chunk)));
+    request.on("end", () => {
+      if (refused < failFirst) {
+        refused += 1;
+        response.writeHead(503).end();
+        return;
+      }
+      received.push(JSON.parse(body) as Record<string, unknown>);
+      response.writeHead(200).end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  const receiver = {
+    url: `http://127.0.0.1:${port}/hook`,
+    received,
+    refusals: () => refused,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+  cleanup.push(() => receiver.close());
+  return receiver;
+}
+
+/**
+ * One server on the production drivers. `queueName` is per-test so BullMQ jobs cannot leak between
+ * cases through the shared Redis.
+ */
+async function startInstance(queueName: string, overrides: Partial<ProtocolDeps> = {}) {
+  const embedded = await embedPostgresGraphs(
+    { echo: buildGraph() },
+    {
+      postgresUri: pg.url,
+      redisUri: redis.url,
+      overrides: {
+        // Short delays so the real BullMQ schedule fits in a test rather than being simulated.
+        webhooks: { retries: { maxAttempts: 6, initialDelayMs: 50 } },
+        deliveryQueue: new RedisDeliveryQueue(redis.url, { queueName, initialDelayMs: 50 }),
+        ...overrides,
+      },
+    },
+  );
+  const runtime = createProtocolRuntime(embedded.deps);
+  await runtime.service.assistants.registerGraphAssistants();
+  runtime.worker.start();
+  cleanup.push(async () => {
+    await runtime.worker.stop();
+    await embedded.dispose();
+  });
+  return { runtime, deps: embedded.deps };
+}
+
+async function runWithWebhook(
+  runtime: Awaited<ReturnType<typeof startInstance>>["runtime"],
+  webhook: string,
+): Promise<string> {
+  const thread = await runtime.service.threads.create();
+  const { runId } = await runtime.service.runs.createWait({
+    thread_id: thread.thread_id,
+    assistant_id: "echo",
+    input: { messages: [] },
+    webhook,
+  });
+  return runId;
+}
+
+describe("durable outbound delivery — Postgres outbox, BullMQ schedule", () => {
+  it("lets BullMQ retry a failed callback until the receiver recovers", async () => {
+    const receiver = await startReceiver(3);
+    const { runtime, deps } = await startInstance("skein-test-retry");
+
+    const runId = await runWithWebhook(runtime, receiver.url);
+
+    // The inline attempt failed, so the row is pending and a BullMQ job now owns the schedule. From
+    // here nothing in skein decides when to try again.
+    await vi.waitFor(async () => expect(receiver.received).toHaveLength(1), {
+      timeout: 20_000,
+      interval: 100,
+    });
+
+    expect(receiver.refusals()).toBe(3);
+    expect(receiver.received[0]).toMatchObject({ run_id: runId, status: "success" });
+    await vi.waitFor(
+      async () => {
+        const [settled] = await deps.store.deliveries!.listByRun(runId);
+        expect(settled?.status).toBe("delivered");
+      },
+      { timeout: 10_000, interval: 100 },
+    );
+  }, 120_000);
+
+  it("gives up after the configured attempts and records the dead letter in the store", async () => {
+    // The receiver never recovers. The dead letter has to end up on the *row* — an operator looks at
+    // skein's delivery list, not at BullMQ's failed set, and the replay endpoint reads the row.
+    const receiver = await startReceiver(Number.MAX_SAFE_INTEGER);
+    const { runtime, deps } = await startInstance("skein-test-dead");
+
+    const runId = await runWithWebhook(runtime, receiver.url);
+
+    await vi.waitFor(
+      async () => {
+        const [settled] = await deps.store.deliveries!.listByRun(runId);
+        expect(settled?.status).toBe("dead");
+      },
+      { timeout: 30_000, interval: 200 },
+    );
+
+    const [dead] = await deps.store.deliveries!.listByRun(runId);
+    expect(dead?.attempt).toBeGreaterThan(1);
+    // Kept, so the replay endpoint has something to resend once the receiver is fixed.
+    expect(dead?.payload).toMatchObject({ run_id: runId });
+    expect(dead?.last_error).toBeTruthy();
+  }, 120_000);
+
+  it("delivers a callback whose retry outlived the instance that created it", async () => {
+    // The property that makes this the production path: the schedule is in Redis, not in a timer that
+    // dies with the process. Instance A fails the inline attempt and is torn down; instance B, which
+    // never saw the run, picks the job up.
+    const receiver = await startReceiver(1);
+    const queueName = "skein-test-handover";
+    const embeddedA = await embedPostgresGraphs(
+      { echo: buildGraph() },
+      {
+        postgresUri: pg.url,
+        redisUri: redis.url,
+        overrides: {
+          webhooks: { retries: { maxAttempts: 6, initialDelayMs: 2_000 } },
+          deliveryQueue: new RedisDeliveryQueue(redis.url, { queueName, initialDelayMs: 2_000 }),
+        },
+      },
+    );
+    const runtimeA = createProtocolRuntime(embeddedA.deps);
+    await runtimeA.service.assistants.registerGraphAssistants();
+    const runId = await runWithWebhook(runtimeA, receiver.url);
+    // A's inline attempt was refused, and the retry is queued but not yet due.
+    expect(receiver.refusals()).toBe(1);
+    expect(receiver.received).toHaveLength(0);
+    // A goes away entirely — no worker, no consumer, no connections.
+    await embeddedA.dispose();
+
+    const { deps } = await startInstance(queueName);
+
+    await vi.waitFor(async () => expect(receiver.received).toHaveLength(1), {
+      timeout: 30_000,
+      interval: 100,
+    });
+    expect(receiver.received[0]).toMatchObject({ run_id: runId });
+    // Awaited rather than asserted straight away: the POST returning and the row being written are two
+    // steps, and reading between them is a flake rather than a finding.
+    await vi.waitFor(
+      async () =>
+        expect((await deps.store.deliveries!.listByRun(runId))[0]?.status).toBe("delivered"),
+      { timeout: 10_000, interval: 100 },
+    );
+  }, 120_000);
+
+  it("recovers a delivery whose job was never enqueued", async () => {
+    // The one window the queue cannot cover, because a Redis `add()` cannot join the Postgres
+    // transaction: the process died between the COMMIT and the enqueue. There is no job, so only the
+    // sweep can find it — which is exactly what the sweep is for.
+    const receiver = await startReceiver();
+    const queueName = "skein-test-lost-job";
+    const lostQueue = new RedisDeliveryQueue(redis.url, { queueName, initialDelayMs: 50 });
+    // Scheduling silently does nothing: the enqueue that should have followed the COMMIT never ran.
+    vi.spyOn(lostQueue, "schedule").mockResolvedValue(undefined);
+    const embedded = await embedPostgresGraphs(
+      { echo: buildGraph() },
+      {
+        postgresUri: pg.url,
+        redisUri: redis.url,
+        overrides: {
+          webhooks: { retries: { maxAttempts: 6, initialDelayMs: 50 } },
+          deliveryQueue: lostQueue,
+          webhookDispatcher: () => Promise.reject(new Error("receiver refused the inline attempt")),
+        },
+      },
+    );
+    const runtime = createProtocolRuntime(embedded.deps);
+    await runtime.service.assistants.registerGraphAssistants();
+    let disposed = false;
+    cleanup.push(async () => {
+      if (!disposed) await embedded.dispose();
+    });
+
+    const thread = await runtime.service.threads.create();
+    const { runId } = await runtime.service.runs.createWait({
+      thread_id: thread.thread_id,
+      assistant_id: "echo",
+      input: { messages: [] },
+      webhook: receiver.url,
+    });
+
+    const [orphan] = await embedded.deps.store.deliveries!.listByRun(runId);
+    expect(orphan?.status).toBe("pending");
+    expect(receiver.received).toHaveLength(0);
+    // The dead instance goes away before the rescue. It was never started, so it never consumed —
+    // which is itself the property being relied on: building a runtime must not start pulling work.
+    await embedded.dispose();
+    disposed = true;
+
+    // A healthy instance sweeps: the row is due, no job exists, so it is handed back to the queue.
+    // `next_attempt_at` is pushed a long way out when a queue owns the schedule, so the sweep is
+    // driven with a clock past that grace rather than by waiting for it.
+    const dueAt = new Date(Date.now() + 6 * 3_600_000);
+    const rescuer = await startInstance(queueName, { clock: () => dueAt });
+    await rescuer.runtime.deliveryWorker.tickOnce();
+
+    await vi.waitFor(async () => expect(receiver.received).toHaveLength(1), {
+      timeout: 20_000,
+      interval: 100,
+    });
+    expect(receiver.received[0]).toMatchObject({ run_id: runId });
+  }, 120_000);
+});

--- a/packages/runtime/src/webhook-delivery.integration.test.ts
+++ b/packages/runtime/src/webhook-delivery.integration.test.ts
@@ -17,7 +17,7 @@
 import { createServer, type Server } from "node:http";
 
 import { MessagesAnnotation, StateGraph } from "@langchain/langgraph";
-import { createProtocolRuntime, DELIVERY_LEASE_MS } from "@skein-js/agent-protocol";
+import { createProtocolRuntime, deliveryLeaseMs } from "@skein-js/agent-protocol";
 import type { ProtocolDeps } from "@skein-js/agent-protocol";
 import { startPostgres, type StartedResource } from "@skein-js/test-support";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -132,13 +132,15 @@ describe("durable outbound delivery — Postgres store, no Redis, two instances"
     expect(receiver.received).toHaveLength(0);
     instanceA.deps.store.deliveries!.recordAttempt = originalRecord;
 
+    // The engine's inline attempt is a batch of one, so that is the lease it took.
+    const lease = deliveryLeaseMs(1, 5_000);
     // Instance B has never heard of this run. It finds the delivery only because the lease lapsed.
     const instanceB = await startInstance({
-      clock: fixedClock(new Date(diedAt.getTime() + DELIVERY_LEASE_MS + 1_000)),
+      clock: fixedClock(new Date(diedAt.getTime() + lease + 1_000)),
     });
     // Before the lease lapses, B must not touch it — or a slow POST would go out twice.
     const early = await startInstance({
-      clock: fixedClock(new Date(diedAt.getTime() + DELIVERY_LEASE_MS - 1_000)),
+      clock: fixedClock(new Date(diedAt.getTime() + lease - 1_000)),
     });
     expect(await early.runtime.deliveryWorker.tickOnce()).toMatchObject({ claimed: 0 });
 

--- a/packages/runtime/src/webhook-delivery.integration.test.ts
+++ b/packages/runtime/src/webhook-delivery.integration.test.ts
@@ -1,0 +1,227 @@
+// Durable outbound delivery on **Postgres with no Redis** — the shape `embedPostgresGraphs` documents
+// as "a single durable instance", and the one where skein's own polling path is the retry mechanism
+// rather than BullMQ's. (The production Postgres + Redis path is
+// `webhook-delivery-redis.integration.test.ts`; the no-Docker path is `webhook-delivery.test.ts`.)
+//
+// This combination is worth its own suite because it is the one where the *store* alone carries every
+// guarantee: the delivery row is written in the run's transaction, `claimDue` hands it to exactly one
+// worker, and the lease on `next_attempt_at` is what recovers a delivery whose process died mid-POST.
+// With Redis, BullMQ owns all three of those; here nothing does but the database.
+//
+// Two *separate* `embedPostgresGraphs` assemblies — separate pools, separate runtimes, separate
+// delivery workers — sharing one database, exactly as `idempotency.integration.test.ts` does. That
+// separation is the whole point: instance A records the delivery and dies; instance B, which has
+// never heard of that run, is the one that delivers it. **This suite fails on `main` by construction,
+// because on `main` there is no row for B to find.**
+
+import { createServer, type Server } from "node:http";
+
+import { MessagesAnnotation, StateGraph } from "@langchain/langgraph";
+import { createProtocolRuntime, DELIVERY_LEASE_MS } from "@skein-js/agent-protocol";
+import type { ProtocolDeps } from "@skein-js/agent-protocol";
+import { startPostgres, type StartedResource } from "@skein-js/test-support";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { embedPostgresGraphs } from "./embed-postgres-graphs.js";
+
+function buildGraph() {
+  return new StateGraph(MessagesAnnotation)
+    .addNode("noop", () => ({ messages: [] }))
+    .addEdge("__start__", "noop")
+    .addEdge("noop", "__end__")
+    .compile();
+}
+
+let pg: StartedResource;
+
+beforeAll(async () => {
+  pg = await startPostgres();
+}, 180_000);
+
+afterAll(async () => {
+  await pg?.stop();
+});
+
+const cleanup: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0)) await dispose();
+});
+
+/** A receiver that records what it is told, and can be taken down. */
+async function startReceiver() {
+  const received: Record<string, unknown>[] = [];
+  const state = { down: false };
+  const server: Server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => (body += String(chunk)));
+    request.on("end", () => {
+      if (state.down) {
+        response.writeHead(503).end();
+        return;
+      }
+      received.push(JSON.parse(body) as Record<string, unknown>);
+      response.writeHead(200).end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  const receiver = {
+    url: `http://127.0.0.1:${port}/hook`,
+    received,
+    setDown: (value: boolean) => {
+      state.down = value;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+  cleanup.push(() => receiver.close());
+  return receiver;
+}
+
+/** One server: its own pool, its own runtime, its own delivery worker. */
+async function startInstance(overrides: Partial<ProtocolDeps> = {}) {
+  // Deliberately no `redisUri`: with one, the retry schedule would be BullMQ's and none of the
+  // store-side machinery below would be exercised.
+  const embedded = await embedPostgresGraphs(
+    { echo: buildGraph() },
+    { postgresUri: pg.url, overrides },
+  );
+  const runtime = createProtocolRuntime(embedded.deps);
+  await runtime.service.assistants.registerGraphAssistants();
+  cleanup.push(() => embedded.dispose());
+  return { runtime, deps: embedded.deps };
+}
+
+const fixedClock =
+  (at: Date): (() => Date) =>
+  () =>
+    new Date(at);
+
+describe("durable outbound delivery — Postgres store, no Redis, two instances", () => {
+  it("hands a delivery whose process died mid-POST to another instance", async () => {
+    const receiver = await startReceiver();
+    const diedAt = new Date("2026-01-01T00:00:00.000Z");
+
+    // Instance A: the callback is recorded in the run's finalize transaction, the inline attempt is
+    // made — and then the process dies before it can record the outcome. Simulated by failing both
+    // the POST and the write that would have recorded the failure, which is precisely the state a
+    // SIGKILL between them leaves behind: a `delivering` row holding a lease nobody will ever release.
+    const instanceA = await startInstance({
+      clock: fixedClock(diedAt),
+      webhookDispatcher: () => Promise.reject(new Error("process died mid-POST")),
+    });
+    const originalRecord = instanceA.deps.store.deliveries!.recordAttempt.bind(
+      instanceA.deps.store.deliveries,
+    );
+    instanceA.deps.store.deliveries!.recordAttempt = () =>
+      Promise.reject(new Error("process died before recording"));
+
+    const thread = await instanceA.runtime.service.threads.create();
+    const { runId } = await instanceA.runtime.service.runs.createWait({
+      thread_id: thread.thread_id,
+      assistant_id: "echo",
+      input: { messages: [] },
+      webhook: receiver.url,
+    });
+
+    // The run succeeded and reports so — which on `main` is the whole bug: a `success` run whose
+    // notification is gone with no record that it was ever owed.
+    expect((await instanceA.deps.store.runs.get(runId))?.status).toBe("success");
+    const [orphan] = await instanceA.deps.store.deliveries!.listByRun(runId);
+    expect(orphan).toMatchObject({ run_id: runId, status: "delivering", attempt: 1 });
+    expect(receiver.received).toHaveLength(0);
+    instanceA.deps.store.deliveries!.recordAttempt = originalRecord;
+
+    // Instance B has never heard of this run. It finds the delivery only because the lease lapsed.
+    const instanceB = await startInstance({
+      clock: fixedClock(new Date(diedAt.getTime() + DELIVERY_LEASE_MS + 1_000)),
+    });
+    // Before the lease lapses, B must not touch it — or a slow POST would go out twice.
+    const early = await startInstance({
+      clock: fixedClock(new Date(diedAt.getTime() + DELIVERY_LEASE_MS - 1_000)),
+    });
+    expect(await early.runtime.deliveryWorker.tickOnce()).toMatchObject({ claimed: 0 });
+
+    expect(await instanceB.runtime.deliveryWorker.tickOnce()).toMatchObject({
+      claimed: 1,
+      delivered: 1,
+    });
+
+    expect(receiver.received).toHaveLength(1);
+    expect(receiver.received[0]).toMatchObject({ run_id: runId, status: "success" });
+    const [settled] = await instanceB.deps.store.deliveries!.listByRun(runId);
+    expect(settled?.status).toBe("delivered");
+    // Cleared on delivery, so storage stays proportional to in-flight deliveries rather than to
+    // every delivery this deployment has ever made.
+    expect(settled?.payload).toBeNull();
+  }, 120_000);
+
+  it("does not let two instances' workers deliver the same row twice", async () => {
+    const receiver = await startReceiver();
+    receiver.setDown(true);
+    const at = new Date("2026-02-01T00:00:00.000Z");
+    const producer = await startInstance({ clock: fixedClock(at) });
+
+    const thread = await producer.runtime.service.threads.create();
+    const { runId } = await producer.runtime.service.runs.createWait({
+      thread_id: thread.thread_id,
+      assistant_id: "echo",
+      input: { messages: [] },
+      webhook: receiver.url,
+    });
+    // The inline attempt failed against a receiver that is down; it is due again after its backoff.
+    expect((await producer.deps.store.deliveries!.listByRun(runId))[0]?.status).toBe("pending");
+
+    receiver.setDown(false);
+    const later = fixedClock(new Date(at.getTime() + 600_000));
+    const [first, second, third] = await Promise.all([
+      startInstance({ clock: later }),
+      startInstance({ clock: later }),
+      startInstance({ clock: later }),
+    ]);
+
+    // Three workers, one due row, one POST. `FOR UPDATE SKIP LOCKED` is what makes this true against
+    // other *connections* — an in-process mutex would pass a single-process test and fail here.
+    const summaries = await Promise.all([
+      first.runtime.deliveryWorker.tickOnce(),
+      second.runtime.deliveryWorker.tickOnce(),
+      third.runtime.deliveryWorker.tickOnce(),
+    ]);
+
+    expect(summaries.reduce((total, one) => total + one.claimed, 0)).toBe(1);
+    expect(receiver.received).toHaveLength(1);
+    expect(receiver.received[0]).toMatchObject({ run_id: runId });
+  }, 120_000);
+
+  it("survives a receiver that is down for a minute, on the durable store", async () => {
+    const receiver = await startReceiver();
+    receiver.setDown(true);
+    const at = new Date("2026-03-01T00:00:00.000Z");
+    const producer = await startInstance({ clock: fixedClock(at) });
+
+    const thread = await producer.runtime.service.threads.create();
+    const { runId } = await producer.runtime.service.runs.createWait({
+      thread_id: thread.thread_id,
+      assistant_id: "echo",
+      input: { messages: [] },
+      webhook: receiver.url,
+    });
+
+    // Sixty seconds of outage, walked forward on a fresh instance per tick so the clock can move.
+    for (const offsetMs of [5_000, 15_000, 30_000, 45_000, 60_000]) {
+      const ticker = await startInstance({ clock: fixedClock(new Date(at.getTime() + offsetMs)) });
+      await ticker.runtime.deliveryWorker.tickOnce();
+    }
+    expect(receiver.received).toHaveLength(0);
+    expect(await producer.deps.store.deliveries!.listByRun(runId, { status: "dead" })).toEqual([]);
+
+    receiver.setDown(false);
+    const recovered = await startInstance({
+      clock: fixedClock(new Date(at.getTime() + 300_000)),
+    });
+    await recovered.runtime.deliveryWorker.tickOnce();
+
+    expect(receiver.received).toHaveLength(1);
+    expect((await producer.deps.store.deliveries!.listByRun(runId))[0]?.status).toBe("delivered");
+  }, 180_000);
+});

--- a/packages/runtime/src/webhook-delivery.test.ts
+++ b/packages/runtime/src/webhook-delivery.test.ts
@@ -1,0 +1,220 @@
+// Success criterion 1 for durable outbound delivery, on the driver combination that needs no Docker:
+//
+//   "An integration test kills the receiver for 60 seconds mid-suite; every notification still
+//    arrives, none marked `dead`."
+//
+// A real `node:http` receiver on loopback rather than a mocked dispatcher, so the default
+// `fetch`-based dispatcher, the retry classification and the outbox all run for real — a mock would
+// prove only that we call our own function. Time is injected and the runtime's own delivery worker is
+// driven with `tickOnce()`, so the sixty seconds pass instantly and nothing here waits on a timer.
+//
+// The Postgres + Redis half of the criterion, and the crash window itself, are in
+// `webhook-delivery.integration.test.ts`.
+
+import { createServer, type Server } from "node:http";
+
+import { MessagesAnnotation, StateGraph } from "@langchain/langgraph";
+import {
+  createProtocolRuntime,
+  DEFAULT_MAX_ATTEMPTS,
+  type ProtocolDeps,
+} from "@skein-js/agent-protocol";
+import { embedInMemoryGraphs } from "@skein-js/server-kit";
+import { afterEach, describe, expect, it } from "vitest";
+
+/** A graph that settles immediately — these tests are about delivery, not execution. */
+function buildGraph() {
+  return new StateGraph(MessagesAnnotation)
+    .addNode("noop", () => ({ messages: [] }))
+    .addEdge("__start__", "noop")
+    .addEdge("noop", "__end__")
+    .compile();
+}
+
+interface Receiver {
+  url: string;
+  /** Bodies actually received, in order. */
+  received: Record<string, unknown>[];
+  /** While true, every request is refused with a 503 — the receiver is "down". */
+  down: boolean;
+  close(): Promise<void>;
+}
+
+async function startReceiver(): Promise<Receiver> {
+  const received: Record<string, unknown>[] = [];
+  const state = { down: false };
+  const server: Server = createServer((request, response) => {
+    let body = "";
+    request.on("data", (chunk) => (body += String(chunk)));
+    request.on("end", () => {
+      if (state.down) {
+        response.writeHead(503).end();
+        return;
+      }
+      received.push(JSON.parse(body) as Record<string, unknown>);
+      response.writeHead(200).end();
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  return {
+    url: `http://127.0.0.1:${port}/hook`,
+    received,
+    get down() {
+      return state.down;
+    },
+    set down(value: boolean) {
+      state.down = value;
+    },
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+const cleanup: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const dispose of cleanup.splice(0)) await dispose();
+});
+
+/** A movable clock, so a sixty-second outage costs the suite nothing. */
+function movableClock(from = new Date("2026-01-01T00:00:00.000Z")) {
+  let now = from.getTime();
+  return {
+    clock: (): Date => new Date(now),
+    advance: (ms: number): void => {
+      now += ms;
+    },
+    nowMs: (): number => now,
+  };
+}
+
+/** An in-process server over the memory drivers, with `clock` (and any policy) injected. */
+async function startServer(overrides: Partial<ProtocolDeps>) {
+  const deps = embedInMemoryGraphs({ echo: buildGraph() }, overrides);
+  const runtime = createProtocolRuntime(deps);
+  await runtime.service.assistants.registerGraphAssistants();
+  return { runtime, deps };
+}
+
+/** Run one graph to completion, asking for a callback at `webhook`. */
+async function runWithWebhook(
+  runtime: Awaited<ReturnType<typeof startServer>>["runtime"],
+  webhook: string,
+): Promise<string> {
+  const thread = await runtime.service.threads.create();
+  const { runId } = await runtime.service.runs.createWait({
+    thread_id: thread.thread_id,
+    assistant_id: "echo",
+    input: { messages: [] },
+    webhook,
+  });
+  return runId;
+}
+
+describe("durable outbound delivery — memory store, in-memory queue, no Docker", () => {
+  it("delivers a notification through a 60-second receiver outage, and never gives up", async () => {
+    const receiver = await startReceiver();
+    cleanup.push(() => receiver.close());
+    const { clock, advance, nowMs } = movableClock();
+    const { runtime, deps } = await startServer({ clock });
+
+    receiver.down = true;
+    const runId = await runWithWebhook(runtime, receiver.url);
+
+    // The run itself is unaffected by the receiver being down — that has always been true, and it is
+    // exactly why the notification used to vanish without trace.
+    expect(receiver.received).toHaveLength(0);
+    const [pending] = await deps.store.deliveries!.listByRun(runId);
+    expect(pending?.status).toBe("pending");
+
+    // Sixty seconds of outage, walked forward one tick at a time.
+    const outageStart = nowMs();
+    while (nowMs() - outageStart < 60_000) {
+      advance(5_000);
+      await runtime.deliveryWorker.tickOnce();
+    }
+    expect(receiver.received).toHaveLength(0);
+
+    receiver.down = false;
+    for (const _ of [0, 1, 2, 3]) {
+      advance(30_000);
+      await runtime.deliveryWorker.tickOnce();
+    }
+
+    // Exactly one body arrived — retried, not duplicated.
+    expect(receiver.received).toHaveLength(1);
+    expect(receiver.received[0]).toMatchObject({ run_id: runId, status: "success" });
+    const [settled] = await deps.store.deliveries!.listByRun(runId);
+    expect(settled?.status).toBe("delivered");
+    expect(settled?.attempt).toBeLessThan(DEFAULT_MAX_ATTEMPTS);
+    // The criterion's sharpest clause: nothing gave up.
+    expect(await deps.store.deliveries!.listByRun(runId, { status: "dead" })).toEqual([]);
+  });
+
+  it("delivers every one of a burst of runs that rode out the same outage", async () => {
+    const receiver = await startReceiver();
+    cleanup.push(() => receiver.close());
+    const { clock, advance } = movableClock();
+    const { runtime } = await startServer({ clock });
+
+    receiver.down = true;
+    const runIds: string[] = [];
+    for (const _ of [0, 1, 2, 3, 4]) runIds.push(await runWithWebhook(runtime, receiver.url));
+
+    for (const _ of [0, 1, 2, 3, 4, 5, 6]) {
+      advance(15_000);
+      await runtime.deliveryWorker.tickOnce();
+    }
+    receiver.down = false;
+    for (const _ of [0, 1, 2, 3, 4]) {
+      advance(60_000);
+      await runtime.deliveryWorker.tickOnce();
+    }
+
+    // Every run, exactly once each. A backlog that drops one is the failure this change exists to
+    // make impossible; a backlog that sends one twice is the failure the delivery id absorbs.
+    expect(receiver.received).toHaveLength(runIds.length);
+    expect(new Set(receiver.received.map((body) => body["run_id"]))).toEqual(new Set(runIds));
+  });
+
+  it("stops after the configured attempts and keeps the payload for a replay", async () => {
+    const receiver = await startReceiver();
+    cleanup.push(() => receiver.close());
+    receiver.down = true;
+    const { clock, advance } = movableClock();
+    const webhooks = { retries: { maxAttempts: 3, initialDelayMs: 1_000 } };
+    const { runtime, deps } = await startServer({ clock, webhooks });
+
+    const runId = await runWithWebhook(runtime, receiver.url);
+    for (const _ of [0, 1, 2, 3]) {
+      advance(30_000);
+      await runtime.deliveryWorker.tickOnce();
+    }
+
+    const [dead] = await deps.store.deliveries!.listByRun(runId);
+    expect(dead?.status).toBe("dead");
+    expect(dead?.attempt).toBe(3);
+    // Kept, so a replay has something to resend once the receiver is fixed — a dead letter you
+    // cannot replay is a log line.
+    expect(dead?.payload).toMatchObject({ run_id: runId });
+  });
+
+  it("refuses a callback to a host outside the allowlist, visibly", async () => {
+    const receiver = await startReceiver();
+    cleanup.push(() => receiver.close());
+    const { clock } = movableClock();
+    const { runtime, deps } = await startServer({
+      clock,
+      webhooks: { allowedHosts: ["hooks.allowed.test"] },
+    });
+
+    const runId = await runWithWebhook(runtime, receiver.url);
+
+    expect(receiver.received).toHaveLength(0);
+    const [refused] = await deps.store.deliveries!.listByRun(runId);
+    // Recorded as dead rather than silently skipped: an operator can see a callback was owed and why
+    // it was not sent, instead of wondering why one never arrived.
+    expect(refused?.status).toBe("dead");
+    expect(refused?.last_error).toContain("allowed_hosts");
+  });
+});

--- a/packages/server-kit/src/in-memory-runtime.ts
+++ b/packages/server-kit/src/in-memory-runtime.ts
@@ -33,6 +33,7 @@ import { embedInMemoryGraphs } from "./in-memory-deps.js";
 import { resolveMaxPageSize } from "./max-page-size.js";
 import { resolveMemoryBusLimits } from "./memory-bus-limits.js";
 import { resolveStoreTtl, resolveThreadTtl } from "./ttl-config.js";
+import { resolveWebhooks } from "./webhooks-config.js";
 
 /**
  * Bridge a config `GraphRegistry` to the engine's `GraphResolver`. They are structurally identical
@@ -142,6 +143,9 @@ export async function loadReloadableInMemoryRuntime(
   // engine reads it, not the store. It has to be resolved on this path anyway, or `skein.idempotency`
   // would tune retention under `skein start` and be silently ignored under `skein dev`.
   const idempotency = resolveIdempotency(first.config.skein?.idempotency);
+  // Same story for `skein.webhooks`: resolved here as well as in `buildRuntime`'s durable branch, or
+  // a retry policy would work under `skein start` and silently do nothing under `skein dev`.
+  const webhooks = resolveWebhooks(first.config.skein?.webhooks);
   const store = new MemorySkeinStore({
     maxPageSize: resolveMaxPageSize(),
     ...(threadTtl ? { threadTtl } : {}),
@@ -161,6 +165,7 @@ export async function loadReloadableInMemoryRuntime(
     ...(threadTtl ? { threadTtl } : {}),
     // Unlike `threadTtl`, absence here means *defaults*, not *off*: the header is honoured either way.
     ...(idempotency ? { idempotency } : {}),
+    ...(webhooks ? { webhooks } : {}),
     ...extraDeps,
   };
 

--- a/packages/server-kit/src/index.ts
+++ b/packages/server-kit/src/index.ts
@@ -75,6 +75,8 @@ export { resolveStoreTtl, resolveThreadTtl } from "./ttl-config.js";
 export type { RawStoreTtl, RawThreadTtl } from "./ttl-config.js";
 export { resolveIdempotency } from "./idempotency-config.js";
 export type { RawIdempotency } from "./idempotency-config.js";
+export { resolveWebhooks } from "./webhooks-config.js";
+export type { RawWebhooks } from "./webhooks-config.js";
 export type {
   InMemoryRuntimeConfig,
   ReloadableInMemoryRuntime,

--- a/packages/server-kit/src/webhooks-config.test.ts
+++ b/packages/server-kit/src/webhooks-config.test.ts
@@ -1,0 +1,64 @@
+// `skein.webhooks` (snake_case) → the engine's camelCase config.
+
+import { describe, expect, it } from "vitest";
+
+import { resolveWebhooks } from "./webhooks-config.js";
+
+describe("resolveWebhooks", () => {
+  it("maps every key to its camelCase counterpart", () => {
+    expect(
+      resolveWebhooks({
+        retries: { max_attempts: 6, initial_delay_ms: 500 },
+        max_payload_bytes: 1_024,
+        retain_hours: 72,
+        allowed_hosts: ["hooks.example.com"],
+      }),
+    ).toEqual({
+      retries: { maxAttempts: 6, initialDelayMs: 500 },
+      maxPayloadBytes: 1_024,
+      retainHours: 72,
+      allowedHosts: ["hooks.example.com"],
+    });
+  });
+
+  it("reports nothing for an absent or empty block, so the defaults apply", () => {
+    // `undefined` here means *defaults*, not disabled — a run carrying a `webhook` owes a callback
+    // whatever the config said. An empty block must be indistinguishable from no block at all.
+    expect(resolveWebhooks(undefined)).toBeUndefined();
+    expect(resolveWebhooks({})).toBeUndefined();
+    expect(resolveWebhooks({ retries: {} })).toBeUndefined();
+  });
+
+  it("carries a partial retry policy without inventing the rest", () => {
+    // The engine fills each missing knob from its own default; filling them here would freeze today's
+    // defaults into every config that set one field.
+    expect(resolveWebhooks({ retries: { max_attempts: 3 } })).toEqual({
+      retries: { maxAttempts: 3 },
+    });
+  });
+
+  it("drops an explicitly empty allowlist rather than reading it as 'allow nothing'", () => {
+    // `"allowed_hosts": []` is what you get from a template or a substitution that produced nothing.
+    // Honouring it literally would kill every callback in the deployment, which no one can have meant.
+    expect(resolveWebhooks({ allowed_hosts: [] })).toBeUndefined();
+  });
+
+  it("copies the allowlist, so a later mutation of the parsed config cannot widen it", () => {
+    const raw = { allowed_hosts: ["hooks.example.com"] };
+    const resolved = resolveWebhooks(raw);
+    raw.allowed_hosts.push("evil.example.com");
+
+    expect(resolved?.allowedHosts).toEqual(["hooks.example.com"]);
+  });
+
+  it("ignores a value of the wrong type instead of passing it through", () => {
+    // The schema rejects these at load, but this resolver is also reachable from an embedder handing
+    // over a hand-built object — and a string where a number belongs would become `NaN` milliseconds.
+    const resolved = resolveWebhooks({
+      retain_hours: "72",
+      retries: { max_attempts: null },
+    } as unknown as Parameters<typeof resolveWebhooks>[0]);
+
+    expect(resolved).toBeUndefined();
+  });
+});

--- a/packages/server-kit/src/webhooks-config.ts
+++ b/packages/server-kit/src/webhooks-config.ts
@@ -1,0 +1,49 @@
+// The `langgraph.json` `skein.webhooks` block (snake_case) → the engine's camelCase config.
+//
+// Here rather than in `@skein-js/runtime` for exactly the reason `ttl-config.ts` and
+// `idempotency-config.ts` give: both assembly paths need it and they do not share one. A retry policy
+// that worked under `skein start` and silently did nothing under `skein dev` is the same failure
+// those two files exist to prevent, and it would be harder to notice here — the symptom is a callback
+// that eventually arrives in production and never arrives in dev.
+
+import type { WebhookDeliveryConfig } from "@skein-js/agent-protocol";
+
+/** The raw `skein.webhooks` block as `langgraph.json` spells it. */
+export interface RawWebhooks {
+  retries?: {
+    max_attempts?: number;
+    initial_delay_ms?: number;
+  };
+  max_payload_bytes?: number;
+  retain_hours?: number;
+  allowed_hosts?: string[];
+}
+
+/**
+ * Map the raw block to {@link WebhookDeliveryConfig}, or `undefined` when nothing is set.
+ *
+ * `undefined` means **defaults, not disabled**, the same distinction `resolveIdempotency` draws: a run
+ * that carries a `webhook` owes a callback whether or not a policy was configured. There is no
+ * setting that stops skein trying — only `retries.max_attempts: 1`, which asks it to try once.
+ */
+export function resolveWebhooks(raw: RawWebhooks | undefined): WebhookDeliveryConfig | undefined {
+  if (!raw) return undefined;
+  const config: WebhookDeliveryConfig = {};
+
+  const retries: NonNullable<WebhookDeliveryConfig["retries"]> = {};
+  if (typeof raw.retries?.max_attempts === "number") retries.maxAttempts = raw.retries.max_attempts;
+  if (typeof raw.retries?.initial_delay_ms === "number") {
+    retries.initialDelayMs = raw.retries.initial_delay_ms;
+  }
+  if (Object.keys(retries).length > 0) config.retries = retries;
+
+  if (typeof raw.max_payload_bytes === "number") config.maxPayloadBytes = raw.max_payload_bytes;
+  if (typeof raw.retain_hours === "number") config.retainHours = raw.retain_hours;
+  // An explicitly empty list is dropped rather than carried, so it cannot be read as "allow nothing"
+  // — a policy no caller can have meant, whose symptom would be every callback dead on arrival.
+  if (Array.isArray(raw.allowed_hosts) && raw.allowed_hosts.length > 0) {
+    config.allowedHosts = [...raw.allowed_hosts];
+  }
+
+  return Object.keys(config).length > 0 ? config : undefined;
+}

--- a/packages/storage-memory/src/memory-skein-store.ts
+++ b/packages/storage-memory/src/memory-skein-store.ts
@@ -755,6 +755,27 @@ export class MemorySkeinStore implements SkeinStore {
     return write(this.#deliveries, delivery.delivery_id, delivery);
   }
 
+  /**
+   * Deliveries due at `now`, soonest first — **stored references, not copies**, so callers clone what
+   * they hand out.
+   *
+   * Synchronous on purpose, like {@link #claimCron}: `claimDue` calls it and must not suspend between
+   * choosing rows and writing them, or two workers could claim the same delivery.
+   */
+  #dueDeliveries(now: string): Delivery[] {
+    const due: Delivery[] = [];
+    for (const delivery of this.#deliveries.values()) {
+      if (delivery.status !== "pending" && delivery.status !== "delivering") continue;
+      if (delivery.next_attempt_at > now) continue;
+      due.push(delivery);
+    }
+    return due.sort((a, b) =>
+      a.next_attempt_at === b.next_attempt_at
+        ? a.delivery_id.localeCompare(b.delivery_id)
+        : a.next_attempt_at.localeCompare(b.next_attempt_at),
+    );
+  }
+
   readonly deliveries: DeliveryRepo = {
     get: async (deliveryId) => readOne(this.#deliveries, deliveryId),
     listByRun: async (runId, query) => {
@@ -773,6 +794,11 @@ export class MemorySkeinStore implements SkeinStore {
       );
       return clonePage(matched, query?.offset ?? 0, this.#pageLimit(query?.limit));
     },
+    // Non-mutating counterpart to `claimDue`, for the recovery sweep — see `DeliveryRepo.listDue`.
+    listDue: async (query) => {
+      const due = this.#dueDeliveries(query.now);
+      return clonePage(due, 0, this.#pageLimit(query.limit));
+    },
     // Atomic for free under the same single-turn rule as `finalizeWithDelivery`: the scan, the sort
     // and every claim write complete before any other caller can run. An `await` anywhere in this
     // body would let two workers claim the same row and double-POST — the case the conformance
@@ -781,17 +807,7 @@ export class MemorySkeinStore implements SkeinStore {
     // The predicate covers due-ness and crash recovery at once: a `delivering` row whose lease has
     // passed is due again, so a worker killed mid-POST needs no reclaim path.
     claimDue: async (query: DueDeliveriesQuery) => {
-      const due: Delivery[] = [];
-      for (const delivery of this.#deliveries.values()) {
-        if (delivery.status !== "pending" && delivery.status !== "delivering") continue;
-        if (delivery.next_attempt_at > query.now) continue;
-        due.push(delivery);
-      }
-      due.sort((a, b) =>
-        a.next_attempt_at === b.next_attempt_at
-          ? a.delivery_id.localeCompare(b.delivery_id)
-          : a.next_attempt_at.localeCompare(b.next_attempt_at),
-      );
+      const due = this.#dueDeliveries(query.now);
       const at = nowIso();
       return due.slice(0, this.#pageLimit(query.limit)).map((delivery) =>
         write(this.#deliveries, delivery.delivery_id, {
@@ -808,16 +824,20 @@ export class MemorySkeinStore implements SkeinStore {
       if (!existing) return null;
       // `delivered` drops the payload, bounding steady-state storage to in-flight deliveries. `dead`
       // keeps it, or a replay would have nothing to resend.
+      // The count is only overwritten when the caller supplies one — see `DeliveryAttemptResult`.
+      const attempt =
+        result.outcome === "delivered" ? existing.attempt : (result.attempt ?? existing.attempt);
       const settled: Delivery =
         result.outcome === "delivered"
           ? { ...existing, status: "delivered", payload: null, last_error: null }
           : result.outcome === "dead"
-            ? { ...existing, status: "dead", last_error: result.error }
+            ? { ...existing, status: "dead", last_error: result.error, attempt }
             : {
                 ...existing,
                 status: "pending",
                 last_error: result.error,
                 next_attempt_at: result.nextAttemptAt,
+                attempt,
               };
       return write(this.#deliveries, deliveryId, { ...settled, updated_at: nowIso() });
     },

--- a/packages/storage-postgres/src/postgres-skein-store.ts
+++ b/packages/storage-postgres/src/postgres-skein-store.ts
@@ -1979,6 +1979,20 @@ export class PostgresSkeinStore implements SkeinStore {
     // The predicate covers due-ness and crash recovery at once: a `delivering` row whose lease has
     // passed is simply due again, so a worker killed mid-POST needs no reclaim path.
     //
+    // Non-mutating, so a recovery sweep may re-read the same rows every pass without spending their
+    // attempt budget. Same predicate and order as the claim below, so the two cannot disagree about
+    // what "due" means.
+    listDue: async (query) => {
+      const { rows } = await this.#pool.query<DeliveryRow>(
+        `SELECT ${DELIVERY_COLUMNS} FROM deliveries
+          WHERE status IN (${DELIVERY_CLAIMABLE_SQL})
+            AND next_attempt_at <= $1::timestamptz
+          ORDER BY next_attempt_at, delivery_id
+          LIMIT $2`,
+        [query.now, this.#pageLimit(query.limit)],
+      );
+      return rows.map(rowToDelivery);
+    },
     // Three CTEs rather than one `UPDATE … WHERE delivery_id IN (…)`, because the contract promises
     // the rows come back soonest-first and an UPDATE's RETURNING order is unspecified. Re-sorting
     // afterwards cannot recover it either: the claim overwrites `next_attempt_at` with the lease, so
@@ -2025,11 +2039,19 @@ export class PostgresSkeinStore implements SkeinStore {
                 "$3::timestamptz",
                 [deliveryId, result.error, result.nextAttemptAt],
               ];
+      // The count is only overwritten when the caller supplies one — see `DeliveryAttemptResult`.
+      const attempt = result.outcome === "delivered" ? undefined : result.attempt;
+      let attemptSql = "attempt";
+      if (attempt !== undefined) {
+        params.push(attempt);
+        attemptSql = `$${params.length}`;
+      }
       const { rows } = await this.#pool.query<DeliveryRow>(
         `UPDATE deliveries
             SET status = ${statusSql},
                 payload = ${payloadSql},
                 last_error = $2,
+                attempt = ${attemptSql},
                 next_attempt_at = ${nextAttemptSql},
                 updated_at = now()
           WHERE delivery_id = $1

--- a/packages/test-support/src/conformance.ts
+++ b/packages/test-support/src/conformance.ts
@@ -2260,6 +2260,78 @@ export function runSkeinStoreConformance(
         expect(claimed.map((row) => row.delivery_id)).toEqual(expected);
       });
 
+      // The read half of the scan-then-act split. It exists so a recovery sweep can look at a
+      // delivery without spending an attempt on it — a claiming sweep would exhaust the budget of
+      // every row it merely glanced at.
+      it("lists due deliveries without claiming them", async () => {
+        const store = await makeStore();
+        const { deliveries, finalize } = outboxOf(store);
+        const { runId, threadId } = await seedRun(store);
+        const { delivery } = await finalize(runId, {
+          status: "success",
+          delivery: deliveryFor(threadId, { next_attempt_at: inMs(-1_000) }),
+        });
+
+        const first = await deliveries.listDue({ now: inMs(0) });
+        expect(first.map((row) => row.delivery_id)).toEqual([delivery.delivery_id]);
+
+        // Still there, still unchanged, still due — reading is free and repeatable.
+        const second = await deliveries.listDue({ now: inMs(0) });
+        expect(second).toEqual(first);
+        const unchanged = await deliveries.get(delivery.delivery_id);
+        expect(unchanged?.attempt).toBe(delivery.attempt);
+        expect(unchanged?.next_attempt_at).toBe(delivery.next_attempt_at);
+        expect(unchanged?.status).toBe(delivery.status);
+      });
+
+      it("hides a delivery that is not due yet from the scan", async () => {
+        const store = await makeStore();
+        const { deliveries, finalize } = outboxOf(store);
+        const { runId, threadId } = await seedRun(store);
+        await finalize(runId, {
+          status: "success",
+          delivery: deliveryFor(threadId, { next_attempt_at: inMs(60_000) }),
+        });
+
+        expect(await deliveries.listDue({ now: inMs(0) })).toEqual([]);
+      });
+
+      it("keeps a settled delivery out of the scan", async () => {
+        const store = await makeStore();
+        const { deliveries, finalize } = outboxOf(store);
+        const { runId, threadId } = await seedRun(store);
+        const { delivery } = await finalize(runId, {
+          status: "success",
+          delivery: deliveryFor(threadId, { next_attempt_at: inMs(-1_000) }),
+        });
+        await deliveries.recordAttempt(delivery.delivery_id, { outcome: "delivered" });
+
+        expect(await deliveries.listDue({ now: inMs(0) })).toEqual([]);
+      });
+
+      it("scans soonest-first, bounded by the driver's page size when no limit is given", async () => {
+        const store = await makeStore({ maxPageSize: 2 });
+        const { deliveries, finalize } = outboxOf(store);
+        const { thread_id } = await store.threads.create();
+        const created = [];
+        for (const offset of [-1_000, -5_000, -3_000]) {
+          const run = await store.runs.create({ thread_id, assistant_id: "a" });
+          const { delivery } = await finalize(run.run_id, {
+            status: "success",
+            delivery: deliveryFor(thread_id, { next_attempt_at: inMs(offset) }),
+          });
+          created.push({ id: delivery.delivery_id, offset });
+        }
+        const expected = [...created]
+          .sort((a, b) => a.offset - b.offset)
+          .slice(0, 2)
+          .map((row) => row.id);
+
+        expect((await deliveries.listDue({ now: inMs(0) })).map((row) => row.delivery_id)).toEqual(
+          expected,
+        );
+      });
+
       it("clears the payload on a delivered attempt", async () => {
         const store = await makeStore();
         const { deliveries, finalize } = outboxOf(store);
@@ -2319,6 +2391,52 @@ export function runSkeinStoreConformance(
         expect(settled?.status).toBe("dead");
         expect(settled?.payload).toEqual(delivery.payload);
         expect(settled?.last_error).toBe("gave up after 12 attempts");
+      });
+
+      // The count is not always the driver's to know: when a `DeliveryQueue` owns the schedule nothing
+      // claims, so the attempt number comes from whoever made the attempt. Without this a delivery
+      // tried a dozen times would still read `attempt: 1` in the admin list and in its headers.
+      it("takes the attempt number from the caller when one is given", async () => {
+        const store = await makeStore();
+        const { deliveries, finalize } = outboxOf(store);
+        const { runId, threadId } = await seedRun(store);
+        const { delivery } = await finalize(runId, {
+          status: "success",
+          delivery: deliveryFor(threadId),
+        });
+
+        const retried = await deliveries.recordAttempt(delivery.delivery_id, {
+          outcome: "retrying",
+          nextAttemptAt: inMs(60_000),
+          error: "down",
+          attempt: 7,
+        });
+        expect(retried?.attempt).toBe(7);
+
+        const dead = await deliveries.recordAttempt(delivery.delivery_id, {
+          outcome: "dead",
+          error: "gave up",
+          attempt: 9,
+        });
+        expect(dead?.attempt).toBe(9);
+      });
+
+      it("keeps the row's own attempt count when the caller gives none", async () => {
+        const store = await makeStore();
+        const { deliveries, finalize } = outboxOf(store);
+        const { runId, threadId } = await seedRun(store);
+        const { delivery } = await finalize(runId, {
+          status: "success",
+          delivery: deliveryFor(threadId),
+        });
+
+        const retried = await deliveries.recordAttempt(delivery.delivery_id, {
+          outcome: "retrying",
+          nextAttemptAt: inMs(60_000),
+          error: "down",
+        });
+        // Unchanged: the polling path advances the count through `claimDue`, not through recording.
+        expect(retried?.attempt).toBe(delivery.attempt);
       });
 
       it("returns null when recording an attempt on an unknown delivery", async () => {


### PR DESCRIPTION
**Stack:** 2 of 3 for #9. Based on #23 (the store contract) — review that first. PR 3 adds signing and the admin list/replay surface and closes the issue.

This is where the outbox starts delivering. A run carrying a `webhook` now records its callback in the run's own finalize transaction, attempts it inline, and retries until it lands or runs out of attempts.

## Redis owns the retry schedule

The first version of this PR hand-rolled a retry loop that behaved identically on every driver. That was the wrong instinct, and it's been rewritten: **in-memory is a development driver, so the design should not be constrained by what it can do.**

With Redis, the entire schedule is BullMQ's — delayed jobs, its built-in `exponential` backoff *with* jitter, and stalled-job recovery instead of a lease of our own. [`redis-delivery-queue.ts`](https://github.com/skein-js/skein-js/blob/feat/delivery-outbox-worker/packages/runtime-redis/src/redis-delivery-queue.ts) is ~140 lines, mostly comments, and the line that matters is:

```ts
backoff: { type: "exponential", delay: this.#initialDelayMs, jitter: JITTER_FRACTION },
```

No custom strategy, no backoff arithmetic. (BullMQ 5.80's `BackoffOptions` takes `jitter` directly; a custom strategy would *replace* the built-in rather than compose with it, so using one would have meant reimplementing what we're trying to reuse.)

| | Retry schedule | Survives a restart? |
| --- | --- | --- |
| **Postgres + Redis** | BullMQ | **Yes** |
| **Postgres, no Redis** | skein polls the outbox | No — but the *delivery* survives; the row is still there |
| **Memory (dev)** | Same poll, in-process | No |

`createProtocolRuntime` warns at startup when the store is durable and the delivery schedule is not. `skein dev --queue redis` runs the production path locally.

## What could not be delegated

A Redis `add()` cannot join a Postgres transaction. So the delivery row is written **with the run's terminal status**, and the job is only ever the schedule — which is what keeps the durability guarantee off Redis entirely. That leaves exactly one gap, a crash between the COMMIT and the enqueue, which the delivery worker sweeps. Same outbox-plus-sweep shape the cron scheduler already uses, for the same reason.

Put differently: the queue decides *when* to try again; the store decides *what is true*. The dead letter lands on the row, not in BullMQ's failed set, because that's what the admin list and the replay endpoint (PR 3) read — and what an operator actually looks at.

## Also here

- **`X-Skein-Delivery-Id` and `X-Skein-Attempt`.** Moved forward from PR 3 deliberately: delivery is at-least-once, and shipping retries *without* giving receivers a dedup key would turn our reliability improvement into their duplicate-processing bug. `WebhookDispatcher` gains an optional third parameter, so every existing dispatcher keeps working.
- **`skein.webhooks`** — attempts, initial delay, payload cap, retention, host allowlist. Resolved on **both** assembly paths, so a policy can't work under `skein start` and silently do nothing under `skein dev`.
- **No `max_delay_ms`.** It never binds at any sane attempt count (12 attempts tops out around 17 minutes), and honouring one would have meant replacing BullMQ's backoff with a hand-written strategy to gain nothing. Not shipping a public knob is the reversible choice.
- **Payload cap** (256 KiB default), with the truncation marker *inside* the body so a receiver can't mistake a truncated `values` for a small one.
- **Fixed: the delivery consumer opened at construction**, so merely building a runtime started pulling other instances' work. It now opens in `worker.start()`, like every other loop here.
- **Fixed: a `recordAttempt` failure after a successful POST** was classified as a failed delivery and scheduled a retry — a second POST to a receiver that already had it.
- Corrects the false "env substitution, which this loader supports" comment in `langgraph-json.ts`. skein does not expand `${VAR}` anywhere in `langgraph.json`, which is why no `skein.*` block takes a secret.

## Behaviour changes worth calling out in review

1. **A callback that used to be lost is now retried.** That is the point, but it means receivers that were silently never hearing about failures will start hearing about them.
2. **Payloads over 256 KiB now arrive truncated** rather than whole. Warned on every truncation, and the marker is in the body.
3. **A retried callback may describe a run that no longer exists.** `deleteThreadIfRunOwnedIt` still runs after the inline attempt, so attempt 1 keeps today's read-back guarantee; attempt 7 an hour later will 404. Direct consequence of storing the payload, and documented.

## Testing

- **674 unit tests** in `agent-protocol`, including the lost-race `run_status` stamp, the two-workers-one-row case, and backoff asserted as a *time horizon* (12 attempts ≈ 34 minutes) rather than a sequence of delays.
- **`webhook-delivery.test.ts`** — success criterion 1 on memory with no Docker: a real loopback receiver held down for 60 seconds, every notification still arrives, none `dead`.
- **`webhook-delivery-redis.integration.test.ts`** — the production path against real Postgres + Redis: BullMQ retrying to recovery, the dead letter landing on the row, a retry outliving the instance that created it, and a job lost between COMMIT and enqueue recovered by the sweep.
- **`webhook-delivery.integration.test.ts`** — Postgres with *no* Redis, where `claimDue` and the lease are the only recovery mechanism.
- Green: `lint typecheck test build` across all 24 projects, and all three integration suites (22 + 209 + 237).
