### PR TITLE
fix(server-kit): give `skein dev` the deps that bind the engine to LangGraph

### DIFF
--- a/examples/triage-agent/src/sweep-graph.ts
+++ b/examples/triage-agent/src/sweep-graph.ts
@@ -91,6 +91,27 @@ function selfClient(headers: Record<string, string> = {}): Client {
   });
 }
 
+/**
+ * The store is a premise of this graph, not an optional extra — so say so instead of degrading.
+ *
+ * All three callers used to guard with `if (store)` and carry on, and the sweep is where that was
+ * worst: with the reads skipped every occurrence re-dispatched the whole backlog, and with the writes
+ * skipped `report` still announced `3 dispatched` over a store holding nothing. That summary is the
+ * evidence that opened this bug.
+ */
+function requireStore(
+  config: LangGraphRunnableConfig,
+): NonNullable<LangGraphRunnableConfig["store"]> {
+  const store = config.store;
+  if (!store) {
+    throw new Error(
+      "no long-term store on the run config — the triage example needs one. Under `skein dev` it " +
+        "is wired automatically; check that the server was started by the skein CLI.",
+    );
+  }
+  return store;
+}
+
 async function fetchWork(state: State): Promise<Partial<State>> {
   return { fetched: await fetchItems({ repo: state.repo, limit: state.limit }) };
 }
@@ -107,8 +128,9 @@ async function filterDecided(
   state: State,
   config: LangGraphRunnableConfig,
 ): Promise<Partial<State>> {
-  const store = config.store;
-  if (!store || state.force) return { fresh: state.fetched, skipped: [] };
+  const store = requireStore(config);
+  // `--force` still re-runs settled items deliberately; that is a request, not a missing store.
+  if (state.force) return { fresh: state.fetched, skipped: [] };
 
   const fresh: TriageItem[] = [];
   const skipped: string[] = [];
@@ -133,7 +155,7 @@ export function routeSweep(state: State): "dispatch" | "report" {
 
 async function dispatch(state: State, config: LangGraphRunnableConfig): Promise<Partial<State>> {
   const client = selfClient();
-  const store = config.store;
+  const store = requireStore(config);
 
   // Confirm the target actually serves the graph we are about to dispatch into, before dispatching
   // anything. `SKEIN_API_URL` defaults to port 2024, so a server started on another port sends its
@@ -172,9 +194,8 @@ async function dispatch(state: State, config: LangGraphRunnableConfig): Promise<
         ifExists: "do_nothing",
       });
 
-      const previousRunId = store
-        ? ((await store.get(DISPATCH_NAMESPACE, key))?.value["runId"] as string | undefined)
-        : undefined;
+      const previousRunId = (await store.get(DISPATCH_NAMESPACE, key))?.value["runId"] as
+        string | undefined;
 
       // A client carrying this item's idempotency key. A second sweep of the same item replays the
       // original response instead of starting a second run.
@@ -190,7 +211,7 @@ async function dispatch(state: State, config: LangGraphRunnableConfig): Promise<
       // Getting the *same* run id back is the idempotency key doing its job, and the only way to
       // observe that from outside is to have remembered what the first sweep produced.
       const replayed = previousRunId === run.run_id;
-      if (store && !replayed) {
+      if (!replayed) {
         await store.put(DISPATCH_NAMESPACE, key, { runId: run.run_id, threadId: thread.thread_id });
       }
       dispatched.push({ key, threadId: thread.thread_id, runId: run.run_id, replayed });
@@ -219,19 +240,16 @@ async function report(state: State, config: LangGraphRunnableConfig): Promise<Pa
     `${started} dispatched, ${replayed} replayed, ${state.skipped.length} already decided` +
     (state.failed.length > 0 ? `, ${state.failed.length} failed` : "");
 
-  const store = config.store;
-  if (store) {
-    // Keyed by time so sweeps accumulate into a readable history rather than overwriting each other.
-    await store.put(SWEEPS_NAMESPACE, new Date().toISOString(), {
-      source: resolveSource(),
-      fetched: state.fetched.length,
-      started,
-      replayed,
-      skipped: state.skipped.length,
-      failed: state.failed,
-      summary,
-    });
-  }
+  // Keyed by time so sweeps accumulate into a readable history rather than overwriting each other.
+  await requireStore(config).put(SWEEPS_NAMESPACE, new Date().toISOString(), {
+    source: resolveSource(),
+    fetched: state.fetched.length,
+    started,
+    replayed,
+    skipped: state.skipped.length,
+    failed: state.failed,
+    summary,
+  });
   return { summary };
 }
 

--- a/examples/triage-agent/src/triage-graph.ts
+++ b/examples/triage-agent/src/triage-graph.ts
@@ -56,6 +56,26 @@ const CONVENTIONS_NAMESPACE = ["triage", "conventions"];
 const DECISIONS_NAMESPACE = ["triage", "decisions"];
 
 /**
+ * The store is a premise of this graph, not an optional extra — so say so instead of degrading.
+ *
+ * Both callers used to guard with `if (store)` and carry on. `record` was the harmful one: it skipped
+ * the write and still returned `recorded as ...`, so a decision could be reported and lost in the same
+ * breath. `gather` merely classified with no context, which is quieter but no more correct.
+ */
+function requireStore(
+  config: LangGraphRunnableConfig,
+): NonNullable<LangGraphRunnableConfig["store"]> {
+  const store = config.store;
+  if (!store) {
+    throw new Error(
+      "no long-term store on the run config — the triage example needs one. Under `skein dev` it " +
+        "is wired automatically; check that the server was started by the skein CLI.",
+    );
+  }
+  return store;
+}
+
+/**
  * Validate the input, before anything expensive happens.
  *
  * Its own node rather than a check inside the next one, so a bad input fails on a step called
@@ -68,12 +88,12 @@ function prepare(state: State): Partial<State> {
 
 /**
  * Read context out of the store: learned conventions, and anything already triaged that looks
- * related. `getStore()` is injected by skein, so this is the same code against in-memory storage
- * under `skein dev` and Postgres + pgvector in production.
+ * related. The store is injected by skein — reachable as `config.store` here, or `getStore()` where
+ * there is no config argument — so this is the same code against in-memory storage under `skein dev`
+ * and Postgres + pgvector in production.
  */
 async function gather(state: State, config: LangGraphRunnableConfig): Promise<Partial<State>> {
-  const store = config.store;
-  if (!store) return { conventions: [], related: [] };
+  const store = requireStore(config);
 
   const [conventions, decisions] = await Promise.all([
     store.search(CONVENTIONS_NAMESPACE, { limit: 10 }),
@@ -183,20 +203,18 @@ async function record(state: State, config: LangGraphRunnableConfig): Promise<Pa
   if (state.approved !== true) {
     return { outcome: `not recorded — ${state.routedBecause ?? "rejected"}` };
   }
-  const store = config.store;
-  if (store) {
-    await store.put(DECISIONS_NAMESPACE, state.item.sourceId, {
-      url: state.item.url,
-      title: state.item.title,
-      author: state.item.author,
-      category: state.verdict?.category,
-      severity: state.verdict?.severity,
-      reply: state.verdict?.reply,
-      decidedBy: state.decidedBy,
-      routedBecause: state.routedBecause,
-      decidedAt: new Date().toISOString(),
-    });
-  }
+  const store = requireStore(config);
+  await store.put(DECISIONS_NAMESPACE, state.item.sourceId, {
+    url: state.item.url,
+    title: state.item.title,
+    author: state.item.author,
+    category: state.verdict?.category,
+    severity: state.verdict?.severity,
+    reply: state.verdict?.reply,
+    decidedBy: state.decidedBy,
+    routedBecause: state.routedBecause,
+    decidedAt: new Date().toISOString(),
+  });
   return {
     outcome: `recorded as ${state.verdict?.category}/${state.verdict?.severity} (${state.decidedBy})`,
   };

--- a/packages/agent-protocol/src/__fixtures__/graphs.ts
+++ b/packages/agent-protocol/src/__fixtures__/graphs.ts
@@ -96,6 +96,27 @@ export const storeGraph: CompiledGraph<string> = new StateGraph(ValueState)
   .addEdge("remember", "__end__")
   .compile() as unknown as CompiledGraph<string>;
 
+/**
+ * The same round trip as {@link storeGraph}, but through `config.store` instead of `getStore()`.
+ *
+ * Both are the same object at runtime (LangGraph runs a node with the very config it puts in
+ * AsyncLocalStorage), but `config.store` is the accessor the docs lead with, and it was the one no
+ * test covered — so an on-ramp that failed to inject `storeBridge` broke the documented pattern
+ * silently, since `config.store?.put(...)` on a missing store is a no-op rather than a throw.
+ */
+export const configStoreGraph: CompiledGraph<string> = new StateGraph(ValueState)
+  .addNode("remember", async (state, config: LangGraphRunnableConfig) => {
+    const store = config.store;
+    if (!store) throw new Error("expected a store on the node's config");
+    await store.put(["memories"], "note", { text: state.value });
+    const item = await store.get(["memories"], "note");
+    const text = (item?.value as { text?: string } | undefined)?.text ?? "?";
+    return { value: `stored: ${text}` };
+  })
+  .addEdge("__start__", "remember")
+  .addEdge("remember", "__end__")
+  .compile() as unknown as CompiledGraph<string>;
+
 /** The fixture graphs keyed by graph id, for a test `GraphResolver`. */
 export const fixtureGraphs: Record<string, CompiledGraph<string>> = {
   echo: echoGraph,
@@ -104,4 +125,5 @@ export const fixtureGraphs: Record<string, CompiledGraph<string>> = {
   "throwing-with-cause": throwingWithCauseGraph,
   slow: slowGraph,
   store: storeGraph,
+  "config-store": configStoreGraph,
 };

--- a/packages/agent-protocol/src/assistants/assistant-service.test.ts
+++ b/packages/agent-protocol/src/assistants/assistant-service.test.ts
@@ -3,6 +3,7 @@ import { MemorySkeinStore } from "@skein-js/storage-memory";
 import { describe, expect, it } from "vitest";
 
 import { createFixtureDeps } from "../__fixtures__/deps.js";
+import { fixtureGraphs } from "../__fixtures__/graphs.js";
 import { createContext, type ProtocolContext } from "../context.js";
 import type { ProtocolDeps } from "../deps.js";
 import { createThreadService } from "../threads/thread-service.js";
@@ -35,20 +36,17 @@ describe("assistant service", () => {
   it("registers one assistant per graph, id defaulting to graph_id, idempotently", async () => {
     const { service } = makeService();
 
+    // Derived from the fixture set rather than frozen as a literal: the property under test is
+    // "one assistant per graph, id defaulting to graph_id", which a hard-coded list restates as
+    // "these six graphs" — so adding a fixture graph fails this test instead of the engine.
+    const graphIds = Object.keys(fixtureGraphs).sort();
     const first = await service.registerGraphAssistants();
-    expect(first.map((a) => a.assistant_id).sort()).toEqual([
-      "echo",
-      "interrupting",
-      "slow",
-      "store",
-      "throwing",
-      "throwing-with-cause",
-    ]);
+    expect(first.map((a) => a.assistant_id).sort()).toEqual(graphIds);
     expect((await service.get("echo")).graph_id).toBe("echo");
 
     // Second registration doesn't duplicate.
     await service.registerGraphAssistants();
-    expect((await service.list()).length).toBe(6);
+    expect((await service.list()).length).toBe(graphIds.length);
   });
 
   it("returns schemas for a known assistant and 404s an unknown one", async () => {

--- a/packages/agent-protocol/src/create-handlers.test.ts
+++ b/packages/agent-protocol/src/create-handlers.test.ts
@@ -7,6 +7,7 @@ import { isSkeinHttpError, SkeinHttpError, type RunEventBus } from "@skein-js/co
 import { describe, expect, it } from "vitest";
 
 import { createFixtureDeps, createFixtureResolver } from "./__fixtures__/deps.js";
+import { fixtureGraphs } from "./__fixtures__/graphs.js";
 import { createContext } from "./context.js";
 import {
   createProtocolHandlers,
@@ -234,7 +235,11 @@ describe("pagination response metadata", () => {
     });
 
     expect(response.kind).toBe("json");
-    expect(response.headers?.["x-pagination-total"]).toBe("6");
+    // The total is "every fixture graph got an assistant", not the literal 6 — the point of the
+    // header is that it ignores `limit: 1`, and pinning the count makes an unrelated fixture fail.
+    expect(response.headers?.["x-pagination-total"]).toBe(
+      String(Object.keys(fixtureGraphs).length),
+    );
   });
 });
 

--- a/packages/agent-protocol/src/runs/run-engine.test.ts
+++ b/packages/agent-protocol/src/runs/run-engine.test.ts
@@ -194,4 +194,22 @@ describe("executeRun", () => {
     const item = await deps.store.store.get(["memories"], "note");
     expect(item?.value).toEqual({ text: "remember me" });
   });
+
+  it("injects the store on the node's own config, the accessor the docs lead with", async () => {
+    const { deps, run, kwargs } = await seed(createFixtureDeps(), "config-store", {
+      value: "remember me",
+    });
+    const control = new RunControlRegistry().register(run.run_id);
+
+    const outcome = await executeRun(deps, { run, kwargs, control });
+
+    // Worth asserting separately from `getStore()` above even though the two read the same object:
+    // `config.store?.put(...)` swallows a missing store, so this is the pattern whose breakage is
+    // invisible, and it is the one docs/state-and-context.md shows first.
+    expect(outcome.status).toBe("success");
+    expect(outcome.values).toEqual({ value: "stored: remember me" });
+    expect((await deps.store.store.get(["memories"], "note"))?.value).toEqual({
+      text: "remember me",
+    });
+  });
 });

--- a/packages/runtime/src/build-runtime.test.ts
+++ b/packages/runtime/src/build-runtime.test.ts
@@ -15,6 +15,26 @@ const fixture = (name: string): string =>
   path.join(path.dirname(fileURLToPath(import.meta.url)), "__fixtures__", name);
 
 describe("buildRuntime — all-memory (skein dev)", () => {
+  it("carries the deps that bind the engine to LangGraph", async () => {
+    const runtime = await buildRuntime({
+      configPath: fixture("langgraph.json"),
+      store: "memory",
+      queue: "memory",
+    });
+    try {
+      // The durable branch below sets these three, and this branch once did not — so a node's
+      // `config.store`/`getStore()` was `undefined`, a thread copy re-`put` the source thread's own
+      // checkpoint object, and `POST /invoke/:graph_id` had no saver. The engine reaches each one
+      // optionally, so all three failures were silent. Asserted here as well as in server-kit
+      // because this is the function `skein dev` actually calls.
+      expect(runtime.deps.storeBridge).toBeTypeOf("function");
+      expect(runtime.deps.cloneCheckpoint).toBeTypeOf("function");
+      expect(runtime.deps.ephemeralCheckpointer).toBeTypeOf("function");
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("honours store.adapter, so a bring-your-own store works under `skein dev`", async () => {
     const runtime = await buildRuntime({
       configPath: fixture("langgraph.adapter.json"),

--- a/packages/server-kit/src/in-memory-runtime.test.ts
+++ b/packages/server-kit/src/in-memory-runtime.test.ts
@@ -1,0 +1,119 @@
+// The dep surface `skein dev` actually runs on.
+//
+// `loadReloadableInMemoryRuntime` used to hand-assemble its `ProtocolDeps`, and drifted from
+// `embedInMemoryGraphs` without anything noticing: it never set `storeBridge`, `cloneCheckpoint` or
+// `ephemeralCheckpointer`. The engine reaches all three optionally, so nothing threw — long-term
+// memory writes from a node simply vanished, a thread copy aliased the source thread's checkpoint,
+// and `POST /invoke/:graph_id` had no saver. These tests pin the surface and, more importantly, prove
+// a node can actually reach the store, which is the part a shape assertion alone would have missed.
+
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { createProtocolRuntime } from "@skein-js/agent-protocol";
+import { afterAll, describe, expect, it } from "vitest";
+
+import { loadReloadableInMemoryRuntime } from "./in-memory-runtime.js";
+
+const created: string[] = [];
+afterAll(async () => {
+  await Promise.all(created.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+// The documented accessor, from docs/state-and-context.md: a node reaches long-term memory through
+// `config.store`. It *throws* on a missing store rather than skipping, because a silent skip is
+// exactly how this bug stayed invisible — `examples/triage-agent` guarded with `if (store)` and its
+// sweeps reported success against an empty store.
+const rememberGraph = `
+import { Annotation, StateGraph, type LangGraphRunnableConfig } from "@langchain/langgraph";
+
+const State = Annotation.Root({
+  value: Annotation({ reducer: (_prev, next) => next, default: () => "" }),
+});
+
+export const graph = new StateGraph(State)
+  .addNode("remember", async (state, config) => {
+    const store = (config as LangGraphRunnableConfig).store;
+    if (!store) throw new Error("no store on the node's config");
+    await store.put(["memories"], "note", { text: state.value });
+    const item = await store.get(["memories"], "note");
+    return { value: "stored: " + (item?.value?.text ?? "?") };
+  })
+  .addEdge("__start__", "remember")
+  .addEdge("remember", "__end__")
+  .compile();
+`;
+
+/** A throwaway project holding one graph, loaded the way `skein dev` loads it. */
+async function project(graphSource: string): Promise<string> {
+  // Inside the workspace, not `os.tmpdir()`: the graph imports `@langchain/langgraph`, and node
+  // resolution only finds it by walking up to the repo's `node_modules`.
+  const dir = await mkdtemp(path.join(process.cwd(), ".tmp-dev-runtime-"));
+  created.push(dir);
+  await writeFile(path.join(dir, "graph.ts"), graphSource);
+  const configPath = path.join(dir, "langgraph.json");
+  await writeFile(
+    configPath,
+    JSON.stringify({ graphs: { remember: "./graph.ts:graph" } }, null, 2),
+  );
+  return configPath;
+}
+
+describe("loadReloadableInMemoryRuntime", () => {
+  it("carries the deps that bind the engine to LangGraph", async () => {
+    const runtime = await loadReloadableInMemoryRuntime(await project(rememberGraph));
+
+    // Each of these was absent, and each failure it caused was silent. Asserted by name rather than
+    // through behaviour so the next omission fails here, on the cheap test, as well as end to end.
+    expect(runtime.deps.storeBridge).toBeTypeOf("function");
+    expect(runtime.deps.cloneCheckpoint).toBeTypeOf("function");
+    expect(runtime.deps.ephemeralCheckpointer).toBeTypeOf("function");
+    // The drivers the path has always had, so a refactor can't quietly drop them either.
+    expect(runtime.deps.store).toBeDefined();
+    expect(runtime.deps.queue).toBeDefined();
+    expect(runtime.deps.bus).toBeDefined();
+    expect(runtime.deps.checkpointer).toBeDefined();
+  });
+
+  it("lets a graph node write to the long-term store through `config.store`", async () => {
+    const runtime = await loadReloadableInMemoryRuntime(await project(rememberGraph));
+    const protocol = createProtocolRuntime(runtime.deps);
+    await protocol.service.assistants.registerGraphAssistants();
+
+    const thread = await protocol.service.threads.create();
+    const { result } = await protocol.service.runs.createWait({
+      thread_id: thread.thread_id,
+      assistant_id: "remember",
+      input: { value: "hello" },
+    });
+
+    // The round trip proves the bridge is attached: the node read back what it had just written.
+    expect(result).toMatchObject({ value: "stored: hello" });
+    // And the item is really in the protocol store — the symptom in the original report was
+    // `POST /store/namespaces` answering `{"namespaces":[]}` after a run that reported success.
+    expect(await runtime.deps.store.store.listNamespaces()).toEqual([["memories"]]);
+  });
+
+  it("still snapshots, hydrates and reloads around the overridden drivers", async () => {
+    const configPath = await project(rememberGraph);
+    const runtime = await loadReloadableInMemoryRuntime(configPath);
+    await runtime.deps.store.store.put(["memories"], "note", { text: "before" });
+
+    const snapshot = runtime.snapshotState();
+    expect(snapshot.store.items?.length ?? 0).toBeGreaterThan(0);
+
+    // A fresh runtime starts empty, then takes the snapshot on — the cross-restart path `skein dev`
+    // uses. Both only work because the store and checkpointer are the instances held on this path.
+    const restored = await loadReloadableInMemoryRuntime(configPath);
+    expect(await restored.deps.store.store.get(["memories"], "note")).toBeNull();
+    restored.hydrateState(snapshot);
+    expect(await restored.deps.store.store.get(["memories"], "note")).toMatchObject({
+      value: { text: "before" },
+    });
+
+    // Reload reroutes graph loads without touching the drivers, so the hydrated item survives it.
+    await restored.reloadGraphs();
+    expect(await restored.deps.store.store.get(["memories"], "note")).not.toBeNull();
+    expect(restored.deps.graphs.ids).toEqual(["remember"]);
+  });
+});

--- a/packages/server-kit/src/in-memory-runtime.ts
+++ b/packages/server-kit/src/in-memory-runtime.ts
@@ -1,7 +1,8 @@
 // Load a `langgraph.json` into a `ProtocolDeps` backed by in-process drivers — the zero-setup runtime
 // that powers `skein dev`. The config-free counterpart (bring a compiled graph in code, no config file)
-// is `embedInMemoryGraphs` in ./in-memory-deps.ts; both assemble the same in-memory drivers, so `skein
-// up` can swap Postgres + Redis deps through the adapters' `{ deps }` seam (see skein-router.ts).
+// is `embedInMemoryGraphs` in ./in-memory-deps.ts, and both entry points here build their deps *through*
+// it, so there is exactly one in-memory assembly site and `skein up` can still swap Postgres + Redis
+// deps through the adapters' `{ deps }` seam (see skein-router.ts).
 
 import { MemorySaver } from "@langchain/langgraph";
 import type {
@@ -20,8 +21,7 @@ import {
   type ModuleImporter,
   type LoadedChannel,
 } from "@skein-js/config";
-import { langGraphResolver } from "@skein-js/langgraph";
-import { MemoryRunEventBus, MemoryRunQueue, MemorySkeinStore } from "@skein-js/storage-memory";
+import { MemorySkeinStore } from "@skein-js/storage-memory";
 import type { CorsOptions } from "cors";
 
 import { corsFromHttpConfig, routesFromHttpConfig } from "./cors-config.js";
@@ -33,7 +33,6 @@ import {
 import { resolveIdempotency } from "./idempotency-config.js";
 import { embedInMemoryGraphs } from "./in-memory-deps.js";
 import { resolveMaxPageSize } from "./max-page-size.js";
-import { resolveMemoryBusLimits } from "./memory-bus-limits.js";
 import { resolveStoreTtl, resolveThreadTtl } from "./ttl-config.js";
 import { resolveWebhooks } from "./webhooks-config.js";
 
@@ -80,7 +79,7 @@ export async function loadInMemoryRuntime(
     importModule,
     staticSchemas,
   });
-  const deps = embedInMemoryGraphs(langGraphResolver(toGraphResolver(graphs)));
+  const deps = embedInMemoryGraphs(toGraphResolver(graphs));
   deps.auth = await loadAuthEngine(config.auth, { configDir, importModule });
   return {
     deps,
@@ -136,13 +135,14 @@ export async function loadReloadableInMemoryRuntime(
   let current: GraphRegistry = first.graphs;
 
   // The resolver delegates to `current` on every call, so swapping it below reroutes future loads.
-  // Wrapped, because these graphs come from `langgraph.json` and are therefore LangGraph graphs: the
-  // engine emits a command envelope and the binding is what turns it back into a `Command`.
-  const graphs: GraphResolver = langGraphResolver({
+  // Left unwrapped: `embedInMemoryGraphs` runs it through `langGraphResolver` below, which is what these
+  // graphs need (they come from `langgraph.json` and are therefore LangGraph graphs — the engine emits a
+  // command envelope and the binding is what turns it back into a `Command`).
+  const graphs: GraphResolver = {
     ids: first.graphs.ids,
     load: (graphId) => current.load(graphId),
     schemas: async (graphId) => (await current.schemas(graphId)) as unknown as GraphSchemas,
-  });
+  };
 
   // Hold the concrete drivers so their state can be snapshot/restored for cross-restart persistence.
   //
@@ -167,22 +167,32 @@ export async function loadReloadableInMemoryRuntime(
     ...(storeTtl ? { ttl: storeTtl } : {}),
   });
   const checkpointer = new MemorySaver();
-  const deps: ProtocolDeps = {
+  // Built *through* `embedInMemoryGraphs` rather than by hand. Hand-assembling this is how `skein dev`
+  // came to run without `storeBridge`, `cloneCheckpoint` and `ephemeralCheckpointer` — the three deps
+  // that bind the engine to LangGraph — while the embed paths had them all along. The engine reaches
+  // each one optionally (`deps.storeBridge?.(…)`), so every consequence was silent: a node's
+  // `config.store`/`getStore()` was `undefined` so long-term memory writes vanished, a thread copy or
+  // rollback re-`put` the *source* thread's own mutable checkpoint object, and `POST /invoke/:graph_id`
+  // had no throwaway saver. Going through the one assembler leaves nothing to drift.
+  //
+  // Only what this path genuinely differs on is overridden: the store carries `maxPageSize` and both
+  // TTLs, and both it and the checkpointer are held above so their state can be snapshot and restored.
+  // `queue` and `bus` are deliberately absent — `embedInMemoryGraphs` builds the same `MemoryRunQueue`
+  // and a `MemoryRunEventBus(resolveMemoryBusLimits())`, so the bounds still reach the longest-lived
+  // memory bus skein runs (this is the path `skein start` and `skein up` take by default).
+  const deps: ProtocolDeps = embedInMemoryGraphs(graphs, {
     store,
-    graphs,
-    queue: new MemoryRunQueue(),
-    // This is the path `skein start` and `skein up` take by default, so it is the longest-lived
-    // memory bus skein runs — the bounds have to be resolved here too, not just on the embed paths.
-    bus: new MemoryRunEventBus(resolveMemoryBusLimits()),
     checkpointer,
     auth: await loadAuthEngine(first.config.auth, { configDir: first.configDir, importModule }),
     // Present only when configured — its presence is what starts the thread TTL sweeper.
     ...(threadTtl ? { threadTtl } : {}),
     // Unlike `threadTtl`, absence here means *defaults*, not *off*: the header is honoured either way.
     ...(idempotency ? { idempotency } : {}),
+    // Resolved from this runtime's config, which `resolveWebhooks` already merges with the environment
+    // — so this subsumes the env-only value `embedInMemoryGraphs` computes, and overrides spread last.
     ...(webhooks ? { webhooks } : {}),
     ...extraDeps,
-  };
+  });
 
   return {
     deps,


### PR DESCRIPTION
Fixes #28.

## The issue's hypothesis was wrong

#28 guessed that LangGraph never populates `config.store` and that the docs and examples should
converge on `getStore()`. Verified against `@langchain/langgraph@1.4.7`, that is not what happens:

- A graph-level `store` **does** reach the node as `config.store` — `pregel/index.js:883`
  (`config.store ?? this.store`) → `loop.js:301` → `algo.js:301`.
- skein's per-call prototype clone works; `store` is a plain writable data property, so the clone
  shadows the shared instance.
- `getStore()` returns *the same object* the node's `config` argument is — `utils.js:20-26` runs the
  node with the very `childConfig` it puts in AsyncLocalStorage.

So switching accessors would have converted a silent skip into a `TypeError`.

## The actual cause

`loadReloadableInMemoryRuntime` hand-assembled its `ProtocolDeps` and had drifted from
`embedInMemoryGraphs`: it never set `storeBridge`, `cloneCheckpoint` or `ephemeralCheckpointer`. The
engine reaches all three optionally, so every consequence was silent — and `buildRuntime` routes
all-memory (`skein dev`'s default, and `skein start` without Postgres/Redis) through that function:

| missing dep | silent consequence |
| --- | --- |
| `storeBridge` | `run-engine.ts:157` → `undefined` → `resolve-compiled-graph.ts:66` skips the assignment → `config.store` **and** `getStore()` both `undefined` in every node |
| `cloneCheckpoint` | thread copy, rollback and `keep_latest` prune re-`put` the *source* thread's own mutable checkpoint object under a second thread id |
| `ephemeralCheckpointer` | `POST /invoke/:graph_id` cannot serve a graph that needs one |

Production (Postgres/Redis) was never affected — `build-runtime.ts`'s durable branch sets all three,
as do `embed-postgres-graphs.ts` and the adapter fixtures. Four sites had them; the fifth did not.

## The fix

Build the deps **through** `embedInMemoryGraphs`, overriding only what this path genuinely differs on
(the `maxPageSize`/TTL-carrying store and the checkpointer, both held locally for
`snapshotState`/`hydrateState`). One in-memory assembly site, so there is nothing left to drift — and
the file header's claim that both paths assemble the same drivers is true again by construction.

`queue` and `bus` are deliberately *not* overridden: the assembler builds the same `MemoryRunQueue`
and `MemoryRunEventBus(resolveMemoryBusLimits())`. Also drops a double `langGraphResolver` wrap on
`loadInMemoryRuntime` — the assembler applies it itself.

## Tests

`packages/server-kit/src/in-memory-runtime.test.ts` **did not exist**, which is why this drifted. It
now pins the dep surface, drives a real run whose node writes through `config.store`, and covers
snapshot/hydrate/reload around the overridden drivers. Reverting the one-file fix fails it with
`no store on the node's config` — the exact reported symptom.

Also: `buildRuntime`'s all-memory branch is asserted (that is what the CLI calls), and the
agent-protocol fixtures gain a `config.store` graph — previously only `getStore()` was covered, so
the accessor the docs lead with had no test at all. Two hard-coded fixture counts became derived from
`fixtureGraphs`, so adding a fixture no longer fails unrelated tests.

## Example

`examples/triage-agent` is what surfaced this. Its nodes guarded with `if (store)` and carried on, so
`record` returned `recorded as ...` while dropping the write, and a sweep announced `3 dispatched`
over an empty store. A missing store now fails the run, where it is visible.

## Docs

None needed — both accessors work after the fix, so `docs/state-and-context.md`,
`docs/langgraph-essentials.md`, `docs/storage.md`, `docs/memory.md` and `docs/your-first-agent.md`
are already correct. #28's request for a docs convergence turns out to be unnecessary.

## Verification

`nx format:check`, `affected -t lint typecheck test build` all green (the `import/order` warnings are
pre-existing in untouched files; the two failing example suites need a live Gemini key and fail on
`main` too, which is why `examples/*` is excluded from the commit gate).