### PR TITLE
fix(console): read relative times forwards, not as negative "ago"

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -219,6 +219,12 @@ Schedules with their assistant, expression, timezone, target thread (or `statele
 occurrence. Pause and resume without deleting, which is the fastest way to stop a noisy schedule
 while you look at it.
 
+The next-occurrence column counts forwards — `in 2h`, `in 3d`, `in 14mo` — and names the states a
+schedule can be in: `paused` when it is disabled, and `no upcoming run` when it is enabled but its
+expression will never fire again. That last one is the case the column exists for; it otherwise looks
+identical to a healthy schedule. A schedule already past due but not yet fired reads in the other
+direction (`2m ago`) — brief while a tick is pending, and a sign the scheduler is stuck if it grows.
+
 Creating one takes an assistant, a 5-field expression and an input. Sub-minute schedules are a
 [deliberate non-goal](./crons.md#semantics), and the form says so rather than failing at submit.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8522,6 +8522,12 @@ Schedules with their assistant, expression, timezone, target thread (or `statele
 occurrence. Pause and resume without deleting, which is the fastest way to stop a noisy schedule
 while you look at it.
 
+The next-occurrence column counts forwards — `in 2h`, `in 3d`, `in 14mo` — and names the states a
+schedule can be in: `paused` when it is disabled, and `no upcoming run` when it is enabled but its
+expression will never fire again. That last one is the case the column exists for; it otherwise looks
+identical to a healthy schedule. A schedule already past due but not yet fired reads in the other
+direction (`2m ago`) — brief while a tick is pending, and a sign the scheduler is stuck if it grows.
+
 Creating one takes an assistant, a 5-field expression and an input. Sub-minute schedules are a
 [deliberate non-goal](./crons.md#semantics), and the form says so rather than failing at submit.
 

--- a/packages/console/ui/src/views/crons.tsx
+++ b/packages/console/ui/src/views/crons.tsx
@@ -95,10 +95,16 @@ export function CronsView() {
                         )}
                       </TableCell>
                       <TableCell>
-                        {enabled ? (
+                        {!enabled ? (
+                          <Badge variant="muted">paused</Badge>
+                        ) : cron.next_run_date ? (
                           <Timestamp value={cron.next_run_date} />
                         ) : (
-                          <Badge variant="muted">paused</Badge>
+                          // Enabled with no next occurrence: the expression parsed but will never
+                          // fire again. `Timestamp` renders a bare `—` for an absent value, which is
+                          // right for a missing `created_at` and useless here — this is exactly the
+                          // state this column exists to expose, so it says so.
+                          <Badge variant="muted">no upcoming run</Badge>
                         )}
                       </TableCell>
                       <TableCell className="text-right">

--- a/packages/console/ui/src/views/parts.test.ts
+++ b/packages/console/ui/src/views/parts.test.ts
@@ -1,0 +1,83 @@
+// Relative-time formatting, both directions.
+//
+// `formatRelative` used to compute `now - date` and test `< 60`, so a future date landed on the
+// seconds rung with a negative count: a cron due in two hours rendered `-7200s ago`. Crons is the only
+// view that renders a future timestamp, and the next-occurrence column is the reason that view exists.
+//
+// `now` is injected rather than mocked so every case is a pure assertion on a string.
+
+import { describe, expect, it } from "vitest";
+
+import { formatRelative } from "./parts.js";
+
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+const at = (secondsFromNow: number): Date => new Date(NOW + secondsFromNow * 1000);
+
+describe("formatRelative — past", () => {
+  it("keeps the terse rungs byte-for-byte", () => {
+    // Unchanged output matters: eight of the nine `Timestamp` call sites render `created_at` or
+    // `updated_at`, and none of them should move because Crons needed fixing.
+    expect(formatRelative(at(0), NOW)).toBe("0s ago");
+    expect(formatRelative(at(-45), NOW)).toBe("45s ago");
+    expect(formatRelative(at(-90), NOW)).toBe("2m ago");
+    expect(formatRelative(at(-7200), NOW)).toBe("2h ago");
+  });
+
+  it("falls through to a calendar date past a day, as it always did", () => {
+    // A distant past row is read off a calendar, so this rung deliberately does *not* gain `d`/`mo`.
+    expect(formatRelative(at(-5 * 86_400), NOW)).toBe(
+      new Date(NOW - 5 * 86_400_000).toLocaleDateString(),
+    );
+  });
+});
+
+describe("formatRelative — future", () => {
+  it("reads forwards instead of signing the count", () => {
+    // The bug, at the rung it was reported on: `-7200s ago` for a schedule due in two hours.
+    expect(formatRelative(at(7200), NOW)).toBe("in 2h");
+    expect(formatRelative(at(30), NOW)).toBe("in 30s");
+    expect(formatRelative(at(120), NOW)).toBe("in 2m");
+  });
+
+  it("keeps counting past a day, so a far-off schedule stays legible", () => {
+    // `crons.tsx` exists to make "never, or a year away" look different from healthy. `in 8760h`
+    // does not, and neither would a bare date.
+    expect(formatRelative(at(3 * 86_400), NOW)).toBe("in 3d");
+    expect(formatRelative(at(60 * 86_400), NOW)).toBe("in 2mo");
+    expect(formatRelative(at(365 * 86_400), NOW)).toBe("in 12mo");
+  });
+});
+
+describe("formatRelative — rung tops promote instead of rounding into their own ceiling", () => {
+  it("never renders a count at its rung's ceiling", () => {
+    // The rung ceiling applies to the *rounded* count, not the raw seconds. Bounding the seconds let
+    // a value round up into its own ceiling: an hourly cron just under the hour read `in 60m`, and a
+    // daily one `in 24h`. Hourly is the commonest schedule there is, so this is the live case.
+    expect(formatRelative(at(3599), NOW)).toBe("in 1h");
+    expect(formatRelative(at(-3599), NOW)).toBe("1h ago");
+    expect(formatRelative(at(86_399), NOW)).toBe("in 1d");
+    expect(formatRelative(at(30 * 86_400 - 1), NOW)).toBe("in 1mo");
+  });
+
+  it("promotes a nearly-day-old past row to a date rather than `24h ago`", () => {
+    // The one place past output moves, and deliberately: the same promotion that makes `in 24h` read
+    // `in 1d` sends the last half hour before a day old to the calendar rung instead.
+    expect(formatRelative(at(-86_399), NOW)).toBe(new Date(NOW - 86_399_000).toLocaleDateString());
+  });
+});
+
+describe("formatRelative — the sub-minute boundary in both directions", () => {
+  it("renders a small clock skew as ahead, not as a negative past", () => {
+    // Not hypothetical: when the server clock leads the browser's, a just-created row is a few
+    // seconds in the future and used to render `-3s ago`.
+    expect(formatRelative(at(3), NOW)).toBe("in 3s");
+  });
+
+  it("crosses each rung boundary without changing sign", () => {
+    expect(formatRelative(at(-59), NOW)).toBe("59s ago");
+    expect(formatRelative(at(-60), NOW)).toBe("1m ago");
+    expect(formatRelative(at(59), NOW)).toBe("in 59s");
+    expect(formatRelative(at(60), NOW)).toBe("in 1m");
+    expect(formatRelative(at(86_400), NOW)).toBe("in 1d");
+  });
+});

--- a/packages/console/ui/src/views/parts.tsx
+++ b/packages/console/ui/src/views/parts.tsx
@@ -130,12 +130,58 @@ export function Timestamp({ value }: { value: string | null | undefined }) {
   );
 }
 
-function formatRelative(date: Date): string {
-  const seconds = Math.round((Date.now() - date.getTime()) / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
-  if (seconds < 86_400) return `${Math.round(seconds / 3600)}h ago`;
-  return date.toLocaleDateString();
+/**
+ * The rungs both directions share. Past rows fall off the end to a date; future rows keep counting.
+ *
+ * `max` is a ceiling on the **rounded count**, not on the raw seconds, and that distinction is the
+ * whole point: bounding the seconds lets a value round up into its own ceiling, so an hourly cron
+ * 3599s out reported `in 60m` rather than `in 1h` (and a daily one `in 24h` rather than `in 1d`).
+ */
+const RUNGS = [
+  { unit: "s", per: 1, max: 60 },
+  { unit: "m", per: 60, max: 60 },
+  { unit: "h", per: 3600, max: 24 },
+] as const;
+
+const DAY_SECONDS = 86_400;
+const MONTH_SECONDS = 2_592_000;
+
+/**
+ * Terse relative time, in **both** directions.
+ *
+ * The sign is an input here, not an accident: this used to compute `now - date` and test `< 60`, so
+ * every future date fell through to the seconds rung and came out signed — a cron due in two hours
+ * read `-7200s ago`. Crons is the only view that renders a future timestamp (`next_run_date`), and it
+ * is the view where the column matters most. The past direction had a quieter version of the same bug:
+ * when the server clock leads the browser's, a just-created row is a few seconds "ahead" and rendered
+ * `-3s ago`.
+ *
+ * Hand-signed rather than `Intl.RelativeTimeFormat`: narrow style renders `2 hr. ago` in `en`, not the
+ * `2h ago` the rest of this file is written to, and a localised unit would make the tests
+ * machine-dependent for no gain.
+ *
+ * **The two directions deliberately diverge past 24h.** A distant past date is best read off a
+ * calendar, so it keeps falling through to `toLocaleDateString()` — every other view renders only
+ * `created_at`/`updated_at`, and their output is unchanged below the day mark. A distant *future*
+ * keeps counting, because `crons.tsx` exists to make a schedule whose next occurrence is "never, or a
+ * year away" look different from a healthy one, and both `in 8760h` and a bare date defeat that.
+ *
+ * The one past-direction shift: rounding to `24h` now promotes to the next rung, so the last half hour
+ * before a day old reads as a date rather than `24h ago`. That is the same trade that turns `in 24h`
+ * into `in 1d`, and at the day mark either reading is fine.
+ */
+export function formatRelative(date: Date, now: number = Date.now()): string {
+  const seconds = Math.round((now - date.getTime()) / 1000);
+  const ahead = seconds < 0;
+  const magnitude = Math.abs(seconds);
+
+  for (const { unit, per, max } of RUNGS) {
+    const count = Math.round(magnitude / per);
+    if (count < max) return ahead ? `in ${count}${unit}` : `${count}${unit} ago`;
+  }
+  if (!ahead) return date.toLocaleDateString();
+  const days = Math.round(magnitude / DAY_SECONDS);
+  return days < 30 ? `in ${days}d` : `in ${Math.round(magnitude / MONTH_SECONDS)}mo`;
 }
 
 /** An id, shortened for the eye, linking to the full resource and keeping the whole value on hover. */


### PR DESCRIPTION
Fixes #27.

`formatRelative` computed `now - date` and tested `< 60`, so every future date landed on the seconds
rung with a negative count. A cron due in two hours rendered `-7200s ago`.

`next_run_date` in Crons is the only future timestamp the console renders — confirmed by auditing all
nine `Timestamp` call sites across six views; the other eight are `created_at`/`updated_at` — and the
next-occurrence column is the reason that view exists (`crons.tsx:1-5`). The past direction had a
quieter version of the same bug: when the server clock leads the browser's, a just-created row is a
few seconds "ahead" and rendered `-3s ago`.

## The fix

The sign is an input now. Past output is unchanged below the day mark, so none of the other eight call
sites move. Futures keep counting past a day into `in 3d` / `in 14mo` rather than `in 8760h`, because
Crons exists to make a schedule whose next occurrence is "never, or a year away" look different from a
healthy one — and a bare date would defeat that just as much.

### Not `Intl.RelativeTimeFormat`, contrary to the issue

The issue suggests `Intl.RelativeTimeFormat` with `style: "narrow"` "reproduces the existing terse
format exactly". It does not: in `en` that renders `2 hr. ago` / `in 2 hr.`, not `2h ago` / `in 2h`.
Adopting it would shift every timestamp in the console and make the tests machine-dependent unless a
locale were pinned. Hand-signing the existing ladder keeps the format and costs the same zero bytes.

## Two things found while fixing it

**Rung ceilings now bound the _rounded_ count, not the raw seconds.** Bounding the seconds let a value
round up into its own ceiling: `Math.round(3599/60)` is `60`, so an hourly cron just under the hour
read `in 60m` instead of `in 1h`, and a daily one `in 24h` instead of `in 1d`. Hourly is the commonest
schedule there is. This was in the original code too, and was unguarded. The one past-direction
consequence: the last half hour before a day old now reads as a date rather than `24h ago` — the same
trade that turns `in 24h` into `in 1d`, and either reading is fine at the day mark.

**An enabled cron with no next occurrence rendered a bare `—`.** `Timestamp` does that for any absent
value, which is right for a missing `created_at` and useless here — a dormant-but-enabled schedule is
precisely what this column exists to expose. It now reads `no upcoming run`, alongside the existing
`paused` badge. Handled in the Crons cell rather than in `Timestamp`, which nine call sites share.

## Tests

`packages/console/ui/src/views/parts.test.ts` is new — **the console UI had no component or unit tests
at all**, though `vite.config.mts` was already configured with `jsdom` and a `.tsx` include glob, so
no config change was needed. `formatRelative` is exported and tested directly with an injected `now`,
so every case is a pure string assertion: both directions at each rung, the rung tops that used to
round into their own ceiling, the sub-minute boundary either side of zero, and the clock-skew case.

## Docs

`docs/console.md`'s Crons section now names the states the column can show, including the
past-but-not-yet-fired case (brief while a tick is pending, a sign of a stuck scheduler if it grows).
`llms-full.txt` regenerated.

The Crons view remains the one view section with no screenshot — the issue notes a screenshot would
have advertised the bug. That blocker is gone, but capture is manual, so it belongs to the docs epic
(#8) rather than here.

## Verification

`nx test console-ui` (34 tests), `lint`/`typecheck` clean, `nx format:check` clean, and the asset
budget is unmoved at 710.4 kB against the 900 kB ceiling in `assets.test.ts` — no dependency added.