### PR TITLE
fix(create-skein-js): make the durable path a scaffolded project ships actually work

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -209,6 +209,13 @@ export POSTGRES_URI=postgres://… REDIS_URI=redis://…
 npx skein start                      # or: node node_modules/skein-js/dist/index.js start
 ```
 
+`skein start` also reads a conventional `.env` from the directory you run it in, as well as one beside
+the config it loads — so running your own build from the project root
+(`skein start -c .skein/build/langgraph.json`) picks up that project's `.env` without exporting
+anything. An artifact never carries a `.env` of its own: it is the Docker build context, and `skein
+build` drops a file `env` from the config for that reason. The ambient environment still wins over
+both, which is what the `export` above relies on.
+
 `skein start` serves the artifact and is the same entrypoint the image uses — the container's `CMD` is
 literally `node /app/node_modules/skein-js/dist/index.js start --store postgres --queue redis --host
 0.0.0.0`. `skein-js` is pinned into the artifact's own dependencies, so the install above puts the CLI

--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -31,8 +31,8 @@ my-agent/
 ├── tsconfig.json           Strict, ESM, bundler resolution
 ├── vitest.config.ts
 ├── compose.dev.yaml        Postgres + Redis — what `start` needs
-├── .env.example            Every value optional for `dev`
-├── .env                    A copy of it, gitignored — never overwritten if one already exists
+├── .env                    Ready to use, gitignored — never overwritten if one already exists
+├── .env.example            A committed reference copy of it
 ├── .gitignore
 ├── README.md               Explains each of these files
 └── src/
@@ -43,22 +43,32 @@ my-agent/
 
 The scripts are the whole skein CLI lifecycle:
 
-| Script         | Command                                    | What it does                                                |
-| -------------- | ------------------------------------------ | ----------------------------------------------------------- |
-| `dev`          | `skein dev --port 2024`                    | In-memory drivers, hot reload, state persisted to `.skein/` |
-| `dev:services` | `docker compose -f compose.dev.yaml up -d` | Postgres + Redis for `start`                                |
-| `build`        | `skein build --artifact-only`              | Graphs → plain JavaScript in `.skein/build`                 |
-| `start`        | `skein start`                              | Serve that build — the production entrypoint                |
-| `typecheck`    | `tsc --noEmit`                             |                                                             |
-| `test`         | `vitest run`                               |                                                             |
+| Script         | Command                                      | What it does                                                |
+| -------------- | -------------------------------------------- | ----------------------------------------------------------- |
+| `dev`          | `skein dev --port 2024`                      | In-memory drivers, hot reload, state persisted to `.skein/` |
+| `dev:services` | `docker compose -f compose.dev.yaml up -d`   | Postgres + Redis, for `dev:postgres` and `start`            |
+| `dev:postgres` | `skein dev … --store postgres --queue redis` | The same hot reload, against the drivers production uses    |
+| `build`        | `skein build --artifact-only`                | Graphs → plain JavaScript in `.skein/build`                 |
+| `start`        | `skein start -c .skein/build/langgraph.json` | Serve that build — the production entrypoint                |
+| `typecheck`    | `tsc --noEmit`                               |                                                             |
+| `test`         | `vitest run`                                 |                                                             |
+
+`start` names the artifact's own `langgraph.json` because `skein start` serves a _build_, not a source
+project: it wants `schemas.json` beside the config it loads, and that file only exists in
+`.skein/build`. Run from the project root like this, it also picks up the `POSTGRES_URI` and
+`REDIS_URI` from the project's `.env` — `skein start` reads a conventional `.env` from its working
+directory as well as from the config's, because an artifact deliberately carries none of its own (it
+is the Docker build context). So `dev:services && build && start` works with nothing to edit first.
 
 Two deliberate choices worth knowing:
 
 - **`dev` never needs a credential or a service.** The `echo` graph is always present and always
   first in `graphs`, so the very first request works with an empty `.env`.
-- **`compose.dev.yaml` is always generated**, not hidden behind a flag. `skein start` is durable-only
-  — it defaults to `--store postgres --queue redis` and fails without `POSTGRES_URI`/`REDIS_URI` — so
-  a project shipping a `start` script has to ship the services it needs, or that script is a trap.
+- **`compose.dev.yaml` is always generated**, not hidden behind a flag, and the `POSTGRES_URI` /
+  `REDIS_URI` in `.env` are live rather than commented out. `skein start` is durable-only — it
+  defaults to `--store postgres --queue redis` and fails without those two — so a project shipping a
+  `start` script has to ship both the services and the URIs that reach them, or the script is a trap.
+  The values are the ones the generated compose file serves, so there was never anything to decide.
 
 ## Options
 

--- a/docs/your-first-agent.md
+++ b/docs/your-first-agent.md
@@ -63,17 +63,19 @@ Eleven files. The three that matter:
 what clients ask for by name. This is the same file format the LangGraph CLI reads, which is why
 skein is a drop-in for it.
 
-**`package.json`** — four commands that are the whole lifecycle:
+**`package.json`** — the commands that are the whole lifecycle:
 
 |                        |                                                              |
 | ---------------------- | ------------------------------------------------------------ |
 | `npm run dev`          | what you're running: hot reload, in-memory state, zero setup |
-| `npm run dev:services` | Postgres + Redis in Docker, needed by `start`                |
+| `npm run dev:services` | Postgres + Redis in Docker, for `dev:postgres` and `start`   |
+| `npm run dev:postgres` | the same hot reload, against those services instead          |
 | `npm run build`        | compile your graphs to plain JavaScript in `.skein/`         |
 | `npm start`            | serve that build — this is what production runs              |
 
-The rest: `.env` and `.env.example` (identical, entirely commented out — nothing in them is required
-yet), `compose.dev.yaml` (the services for `start`), `tsconfig.json`, a test, and a README.
+The rest: `.env` (ready to use — the model key is commented out, the service URIs are not) and
+`.env.example` (a committed reference copy of it), `compose.dev.yaml` (the services for `start`),
+`tsconfig.json`, a test, and a README.
 
 ## 4. Understanding the graph
 
@@ -248,10 +250,12 @@ and your node code does not change. See [storage.md](./storage.md) and [memory.m
 
 ```bash
 npm run dev:services    # Postgres + Redis via Docker
-# uncomment POSTGRES_URI and REDIS_URI in .env
 npm run build           # graphs → plain JavaScript in .skein/build
 npm start
 ```
+
+Nothing to edit first: the `POSTGRES_URI` and `REDIS_URI` in `.env` already match those services, and
+`npm start` loads them itself.
 
 `build` compiles your TypeScript graphs ahead of time; `start` serves that output with no TypeScript
 toolchain in the loop. It is exactly what the production container runs.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1519,17 +1519,19 @@ Eleven files. The three that matter:
 what clients ask for by name. This is the same file format the LangGraph CLI reads, which is why
 skein is a drop-in for it.
 
-**`package.json`** — four commands that are the whole lifecycle:
+**`package.json`** — the commands that are the whole lifecycle:
 
 |                        |                                                              |
 | ---------------------- | ------------------------------------------------------------ |
 | `npm run dev`          | what you're running: hot reload, in-memory state, zero setup |
-| `npm run dev:services` | Postgres + Redis in Docker, needed by `start`                |
+| `npm run dev:services` | Postgres + Redis in Docker, for `dev:postgres` and `start`   |
+| `npm run dev:postgres` | the same hot reload, against those services instead          |
 | `npm run build`        | compile your graphs to plain JavaScript in `.skein/`         |
 | `npm start`            | serve that build — this is what production runs              |
 
-The rest: `.env` and `.env.example` (identical, entirely commented out — nothing in them is required
-yet), `compose.dev.yaml` (the services for `start`), `tsconfig.json`, a test, and a README.
+The rest: `.env` (ready to use — the model key is commented out, the service URIs are not) and
+`.env.example` (a committed reference copy of it), `compose.dev.yaml` (the services for `start`),
+`tsconfig.json`, a test, and a README.
 
 ## 4. Understanding the graph
 
@@ -1704,10 +1706,12 @@ and your node code does not change. See [storage.md](./storage.md) and [memory.m
 
 ```bash
 npm run dev:services    # Postgres + Redis via Docker
-# uncomment POSTGRES_URI and REDIS_URI in .env
 npm run build           # graphs → plain JavaScript in .skein/build
 npm start
 ```
+
+Nothing to edit first: the `POSTGRES_URI` and `REDIS_URI` in `.env` already match those services, and
+`npm start` loads them itself.
 
 `build` compiles your TypeScript graphs ahead of time; `start` serves that output with no TypeScript
 toolchain in the loop. It is exactly what the production container runs.
@@ -1959,8 +1963,8 @@ my-agent/
 ├── tsconfig.json           Strict, ESM, bundler resolution
 ├── vitest.config.ts
 ├── compose.dev.yaml        Postgres + Redis — what `start` needs
-├── .env.example            Every value optional for `dev`
-├── .env                    A copy of it, gitignored — never overwritten if one already exists
+├── .env                    Ready to use, gitignored — never overwritten if one already exists
+├── .env.example            A committed reference copy of it
 ├── .gitignore
 ├── README.md               Explains each of these files
 └── src/
@@ -1971,22 +1975,32 @@ my-agent/
 
 The scripts are the whole skein CLI lifecycle:
 
-| Script         | Command                                    | What it does                                                |
-| -------------- | ------------------------------------------ | ----------------------------------------------------------- |
-| `dev`          | `skein dev --port 2024`                    | In-memory drivers, hot reload, state persisted to `.skein/` |
-| `dev:services` | `docker compose -f compose.dev.yaml up -d` | Postgres + Redis for `start`                                |
-| `build`        | `skein build --artifact-only`              | Graphs → plain JavaScript in `.skein/build`                 |
-| `start`        | `skein start`                              | Serve that build — the production entrypoint                |
-| `typecheck`    | `tsc --noEmit`                             |                                                             |
-| `test`         | `vitest run`                               |                                                             |
+| Script         | Command                                      | What it does                                                |
+| -------------- | -------------------------------------------- | ----------------------------------------------------------- |
+| `dev`          | `skein dev --port 2024`                      | In-memory drivers, hot reload, state persisted to `.skein/` |
+| `dev:services` | `docker compose -f compose.dev.yaml up -d`   | Postgres + Redis, for `dev:postgres` and `start`            |
+| `dev:postgres` | `skein dev … --store postgres --queue redis` | The same hot reload, against the drivers production uses    |
+| `build`        | `skein build --artifact-only`                | Graphs → plain JavaScript in `.skein/build`                 |
+| `start`        | `skein start -c .skein/build/langgraph.json` | Serve that build — the production entrypoint                |
+| `typecheck`    | `tsc --noEmit`                               |                                                             |
+| `test`         | `vitest run`                                 |                                                             |
+
+`start` names the artifact's own `langgraph.json` because `skein start` serves a _build_, not a source
+project: it wants `schemas.json` beside the config it loads, and that file only exists in
+`.skein/build`. Run from the project root like this, it also picks up the `POSTGRES_URI` and
+`REDIS_URI` from the project's `.env` — `skein start` reads a conventional `.env` from its working
+directory as well as from the config's, because an artifact deliberately carries none of its own (it
+is the Docker build context). So `dev:services && build && start` works with nothing to edit first.
 
 Two deliberate choices worth knowing:
 
 - **`dev` never needs a credential or a service.** The `echo` graph is always present and always
   first in `graphs`, so the very first request works with an empty `.env`.
-- **`compose.dev.yaml` is always generated**, not hidden behind a flag. `skein start` is durable-only
-  — it defaults to `--store postgres --queue redis` and fails without `POSTGRES_URI`/`REDIS_URI` — so
-  a project shipping a `start` script has to ship the services it needs, or that script is a trap.
+- **`compose.dev.yaml` is always generated**, not hidden behind a flag, and the `POSTGRES_URI` /
+  `REDIS_URI` in `.env` are live rather than commented out. `skein start` is durable-only — it
+  defaults to `--store postgres --queue redis` and fails without those two — so a project shipping a
+  `start` script has to ship both the services and the URIs that reach them, or the script is a trap.
+  The values are the ones the generated compose file serves, so there was never anything to decide.
 
 ## Options
 
@@ -10055,6 +10069,13 @@ cd /srv/skein && npm install --omit=dev
 export POSTGRES_URI=postgres://… REDIS_URI=redis://…
 npx skein start                      # or: node node_modules/skein-js/dist/index.js start
 ```
+
+`skein start` also reads a conventional `.env` from the directory you run it in, as well as one beside
+the config it loads — so running your own build from the project root
+(`skein start -c .skein/build/langgraph.json`) picks up that project's `.env` without exporting
+anything. An artifact never carries a `.env` of its own: it is the Docker build context, and `skein
+build` drops a file `env` from the config for that reason. The ambient environment still wins over
+both, which is what the `export` above relies on.
 
 `skein start` serves the artifact and is the same entrypoint the image uses — the container's `CMD` is
 literally `node /app/node_modules/skein-js/dist/index.js start --store postgres --queue redis --host

--- a/packages/cli/src/project-env.test.ts
+++ b/packages/cli/src/project-env.test.ts
@@ -1,0 +1,91 @@
+// Env resolution for the CLI commands, and specifically the case `skein start` needs.
+//
+// `skein start` serves a *build*, so its `configDir` is `.skein/build` — and an artifact deliberately
+// carries no `.env` of its own (it is the Docker build context, and `skein build` drops a file `env`
+// for the same reason). Without a second conventional read, a scaffolded project's own
+// `POSTGRES_URI`/`REDIS_URI` were never seen by the one entrypoint that requires them, so
+// `npm run build && npm start` failed on a project that looked correctly configured.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import type { LanggraphJson } from "@skein-js/config";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { applyProjectEnv } from "./project-env.js";
+
+const config = { graphs: {} } as unknown as LanggraphJson;
+
+let root: string;
+let artifact: string;
+let KEY: string;
+const used: string[] = [];
+
+beforeEach(async () => {
+  root = mkdtempSync(path.join(tmpdir(), "skein-project-env-"));
+  artifact = path.join(root, ".skein", "build");
+  await mkdir(artifact, { recursive: true });
+  // A fresh variable per case. The module remembers which keys *it* set, so that `skein dev`'s
+  // reload can correct a value it applied earlier (see `appliedKeys`) — which means a key reused
+  // across cases would arrive already marked as skein's own and stop behaving like an ambient one.
+  KEY = `SKEIN_PROJECT_ENV_TEST_${used.length}`;
+  used.push(KEY);
+});
+
+afterEach(() => {
+  for (const key of used) delete process.env[key];
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("applyProjectEnv", () => {
+  it("reads a .env from the working directory when the config lives elsewhere", async () => {
+    writeFileSync(path.join(root, ".env"), `${KEY}=from-the-project\n`);
+
+    await applyProjectEnv(config, artifact, { alsoReadDotEnvIn: root });
+
+    expect(process.env[KEY]).toBe("from-the-project");
+  });
+
+  it("does not read the working directory unless asked", async () => {
+    // `skein dev` loads a source project, where the config already sits in the directory it would
+    // read — opting in per command keeps this from widening what `dev` and `import-langgraph` see.
+    writeFileSync(path.join(root, ".env"), `${KEY}=from-the-project\n`);
+
+    await applyProjectEnv(config, artifact);
+
+    expect(process.env[KEY]).toBeUndefined();
+  });
+
+  it("ranks the config's own directory above the working directory", async () => {
+    // Both exist only when someone has put a `.env` in an artifact deliberately. It is the more
+    // specific of the two, so it wins.
+    writeFileSync(path.join(root, ".env"), `${KEY}=from-the-project\n`);
+    writeFileSync(path.join(artifact, ".env"), `${KEY}=from-the-artifact\n`);
+
+    await applyProjectEnv(config, artifact, { alsoReadDotEnvIn: root });
+
+    expect(process.env[KEY]).toBe("from-the-artifact");
+  });
+
+  it("never clobbers the ambient environment", async () => {
+    // The dotenv convention, and what the documented `export POSTGRES_URI=… && skein start` relies
+    // on: a platform-injected value has to outrank a file that happens to be lying next to the code.
+    process.env[KEY] = "from-the-platform";
+    writeFileSync(path.join(root, ".env"), `${KEY}=from-the-project\n`);
+
+    await applyProjectEnv(config, artifact, { alsoReadDotEnvIn: root });
+
+    expect(process.env[KEY]).toBe("from-the-platform");
+  });
+
+  it("is a no-op when the working directory is the config's directory", async () => {
+    // The guard that stops the same file being read and parsed twice.
+    writeFileSync(path.join(artifact, ".env"), `${KEY}=from-the-artifact\n`);
+
+    await applyProjectEnv(config, artifact, { alsoReadDotEnvIn: artifact });
+
+    expect(process.env[KEY]).toBe("from-the-artifact");
+  });
+});

--- a/packages/cli/src/project-env.ts
+++ b/packages/cli/src/project-env.ts
@@ -1,8 +1,8 @@
 // Shared env resolution for the CLI commands. A conventional `.env` in the project is the base,
 // `langgraph.json`'s declared `env` overrides it, and the ambient environment wins over both
-// (dotenv convention). Both `skein dev` and `skein import-langgraph` apply env this way, so keeping
-// it in one place stops the two commands from resolving the same project's env (e.g. POSTGRES_URI)
-// differently. `resolveEnv` itself is intentionally pure (it just computes the map); this is the
+// (dotenv convention). `skein dev`, `skein start` and `skein import-langgraph` all apply env this
+// way, so keeping it in one place stops them from resolving the same project's env (e.g.
+// POSTGRES_URI) differently. `resolveEnv` itself is intentionally pure (it just computes the map); this is the
 // thin "apply to process.env" layer on top.
 
 import { existsSync, readFileSync } from "node:fs";
@@ -69,13 +69,29 @@ function readConventionalDotEnv(dir: string): Record<string, string> {
  * `env` file is missing but continues — once per process, not once per call, since `skein dev` calls
  * this again on every reload. Skips the conventional `.env` read when the declared
  * `env` already points at the same file, so it isn't read and parsed twice.
+ *
+ * `alsoReadDotEnvIn` adds a second conventional `.env`, ranked *below* everything else — see below.
  */
-export async function applyProjectEnv(config: LanggraphJson, configDir: string): Promise<void> {
+export async function applyProjectEnv(
+  config: LanggraphJson,
+  configDir: string,
+  options: { alsoReadDotEnvIn?: string } = {},
+): Promise<void> {
   const declaredEnvPath =
     typeof config.env === "string" ? path.resolve(configDir, config.env) : undefined;
   const conventional =
     declaredEnvPath === path.join(configDir, ".env") ? {} : readConventionalDotEnv(configDir);
-  applyEnv({ ...conventional, ...(await resolveEnv(config, configDir)) });
+  // A second conventional `.env`, at the lowest precedence, for a command whose config does not sit
+  // in the project. `skein start` is the only such command: it serves a *build*, so `configDir` is
+  // `.skein/build`, and a build deliberately carries no `.env` — it is the Docker build context, and
+  // `write-manifest` drops a file `env` for the same reason. Without this the URIs a scaffolded
+  // project ships in its own `.env` are never seen by the entrypoint that requires them.
+  const extra =
+    options.alsoReadDotEnvIn !== undefined &&
+    path.resolve(options.alsoReadDotEnvIn) !== path.resolve(configDir)
+      ? readConventionalDotEnv(options.alsoReadDotEnvIn)
+      : {};
+  applyEnv({ ...extra, ...conventional, ...(await resolveEnv(config, configDir)) });
   if (declaredEnvPath !== undefined && !existsSync(declaredEnvPath) && !warnedMissingEnvFile) {
     warnedMissingEnvFile = true;
     console.warn(`skein: env file "${config.env}" not found; continuing without it.`);

--- a/packages/cli/src/start-command.ts
+++ b/packages/cli/src/start-command.ts
@@ -125,8 +125,13 @@ export async function runStart(options: StartCommandOptions): Promise<void> {
     configDir = loaded.configDir;
     authPath = loaded.config.auth?.path;
     httpConfig = loaded.config.http;
-    // Apply an inline `env` map baked into the production config (a file `env` was dropped at build).
-    await applyProjectEnv(loaded.config, configDir);
+    // Apply an inline `env` map baked into the production config (a file `env` was dropped at build),
+    // plus a conventional `.env` in the working directory. The latter is what lets a project run its
+    // own build — `skein start -c .skein/build/langgraph.json` from the project root — without
+    // exporting `POSTGRES_URI`/`REDIS_URI` by hand: the artifact has no `.env` of its own by design,
+    // so the project's is the only one there is. Lowest precedence, so nothing baked into the
+    // artifact and nothing already in the ambient environment is overridden by it.
+    await applyProjectEnv(loaded.config, configDir, { alsoReadDotEnvIn: process.cwd() });
     // Flag → LangGraph-compat alias → SKEIN_RUN_CONCURRENCY → N_JOBS_PER_WORKER → default. Inside this
     // block so a bad value prints `skein: …` and exits 1, like every other boot-config failure.
     runConcurrency = resolveRunConcurrency(options.concurrency ?? options.nJobsPerWorker);

--- a/packages/create-skein-js/README.md
+++ b/packages/create-skein-js/README.md
@@ -25,12 +25,13 @@ No database, no Docker, and no API key — `echo` answers your first request imm
 
 A `langgraph.json` project driven by the `skein` CLI — the same lifecycle you ship with:
 
-| Command        | What it does                                                       |
-| -------------- | ------------------------------------------------------------------ |
-| `dev`          | In-memory drivers, hot reload, dev state persisted across restarts |
-| `dev:services` | Postgres + Redis via Docker Compose, which `start` needs           |
-| `build`        | Bundle the graphs to plain JavaScript in `.skein/build`            |
-| `start`        | Serve that bundle — the production entrypoint                      |
+| Command        | What it does                                                        |
+| -------------- | ------------------------------------------------------------------- |
+| `dev`          | In-memory drivers, hot reload, dev state persisted across restarts  |
+| `dev:services` | Postgres + Redis via Docker Compose, for `dev:postgres` and `start` |
+| `dev:postgres` | The same hot reload, against the drivers production uses            |
+| `build`        | Bundle the graphs to plain JavaScript in `.skein/build`             |
+| `start`        | Serve that bundle — the production entrypoint                       |
 
 ...plus an echo graph that runs with no credentials, a test for it, an optional model-backed ReAct
 agent, and a README explaining every file.

--- a/packages/create-skein-js/src/package-manifest.ts
+++ b/packages/create-skein-js/src/package-manifest.ts
@@ -22,12 +22,25 @@ function scriptsFor(): Record<string, string> {
     // The drop-in for `langgraph dev`: TypeScript loaded in-process, hot reload, and dev state
     // persisted to .skein/ across restarts. Runs on in-memory drivers — nothing to install.
     dev: "skein dev --port 2024",
-    // `start` is durable-only, so this is what makes it runnable locally.
-    "dev:services": "docker compose -f compose.dev.yaml up -d",
+    // `start` and `dev:postgres` are durable-only, so this is what makes them runnable locally.
+    // `--wait`, not a bare `up -d`: without it this returns once the containers are *created*, and
+    // the documented `dev:services && build && start` chain then races first-boot `initdb`. The
+    // compose file declares healthchecks for both services precisely so this can block on them.
+    "dev:services": "docker compose -f compose.dev.yaml up -d --wait",
+    // Develop against the drivers production actually uses. The CLI has always supported this; no
+    // scaffolded script exposed it, so finding it meant finding flags the project never mentions.
+    "dev:postgres": "skein dev --port 2024 --store postgres --queue redis",
     // `--artifact-only` stops at .skein/build instead of invoking Docker, so `build` + `start` work
     // on a machine with no Docker daemon. Drop the flag (or use `skein up`) to get an image.
     build: "skein build --artifact-only",
-    start: "skein start",
+    // `skein start` serves the *artifact*, so it needs the artifact's own `langgraph.json`: a bare
+    // `skein start` resolves `langgraph.json` from the cwd and dies on the missing `schemas.json`
+    // beside it, which made the generated README's "Ship it" steps fail at the last one.
+    //
+    // Run through the bin shim, from the project root. The URIs in `.env` are picked up because
+    // `skein start` reads a conventional `.env` from its working directory as well as from the
+    // config's — the artifact has none of its own by design (it is the Docker build context).
+    start: "skein start -c .skein/build/langgraph.json",
     typecheck: "tsc --noEmit",
     test: "vitest run",
   };

--- a/packages/create-skein-js/src/project-files.test.ts
+++ b/packages/create-skein-js/src/project-files.test.ts
@@ -44,9 +44,27 @@ describe.each(everyProvider)("a project scaffolded with --provider %s", (provide
     const emitted = new Set(files.map((file) => file.path));
 
     expect(emitted.has(config.env)).toBe(true);
-    expect(files.find((file) => file.path === ".env")!.contents).toBe(
-      files.find((file) => file.path === ".env.example")!.contents,
-    );
+
+    // The two come from one template but must not be byte-identical: they were, so the file that
+    // *is* `.env` opened by telling you to copy it to `.env`.
+    const dotEnv = files.find((file) => file.path === ".env")!.contents;
+    const example = files.find((file) => file.path === ".env.example")!.contents;
+    expect(dotEnv).not.toBe(example);
+    // The instruction itself, not the word "copy". `.env` must not tell you to produce `.env` — it
+    // is `.env`. `.env.example` must, because it is the only one of the two a fresh clone gets.
+    expect(dotEnv).not.toMatch(/copy this file to `?\.env/i);
+    expect(example).toMatch(/copy this file to `?\.env/i);
+    // Only the header differs. Compared from the first divider rather than by line count, because
+    // the two headers are deliberately different lengths — everything a reader would actually set
+    // has to stay identical, or the "reference copy" stops being one.
+    const body = (contents: string): string => {
+      const divider = contents.indexOf("# ---");
+      // Guarded: `slice(-1)` would compare one character and pass whatever the two files held.
+      expect(divider, "no `# ---` divider to compare bodies from").toBeGreaterThan(-1);
+      return contents.slice(divider);
+    };
+    expect(body(dotEnv)).toBe(body(example));
+    expect(body(dotEnv)).toContain("POSTGRES_URI=");
 
     // …and it must stay out of git, since a real one will hold real keys.
     expect(files.find((file) => file.path === ".gitignore")!.contents).toMatch(/^\.env$/m);
@@ -271,7 +289,14 @@ describe("the scripts a scaffolded project ships", () => {
 
     expect(manifest.scripts["dev"]).toContain("skein dev");
     expect(manifest.scripts["build"]).toContain("skein build");
-    expect(manifest.scripts["start"]).toBe("skein start");
+    // Durable development, which the CLI always supported and no script exposed.
+    expect(manifest.scripts["dev:postgres"]).toContain("--store postgres");
+    expect(manifest.scripts["dev:postgres"]).toContain("--queue redis");
+
+    // `start` serves the *artifact*, so it must point at the artifact's own `langgraph.json`. A bare
+    // `skein start` resolves `langgraph.json` from the cwd and dies on the missing `schemas.json`
+    // beside it — which made the generated README's own "Ship it" steps fail at the last one.
+    expect(manifest.scripts["start"]).toBe("skein start -c .skein/build/langgraph.json");
   });
 
   // `skein start` defaults to --store postgres --queue redis and fails without them, so a project
@@ -292,9 +317,17 @@ describe("the scripts a scaffolded project ships", () => {
     expect(compose.contents).toContain('"127.0.0.1:5432:5432"');
     expect(compose.contents).toContain('"127.0.0.1:6379:6379"');
 
+    // Uncommented, not merely present: they used to be commented out, so the documented `start`
+    // step failed and the README told you to hand-edit a file in the middle of the happy path. The
+    // values match the compose file above, so there was never anything for the user to decide.
     const envExample = files.find((file) => file.path === ".env.example")!;
-    expect(envExample.contents).toContain("POSTGRES_URI");
-    expect(envExample.contents).toContain("REDIS_URI");
+    expect(envExample.contents).toMatch(
+      /^POSTGRES_URI=postgresql:\/\/postgres:postgres@localhost:5432\/skein$/m,
+    );
+    expect(envExample.contents).toMatch(/^REDIS_URI=redis:\/\/localhost:6379$/m);
+    const dotEnv = files.find((file) => file.path === ".env")!;
+    expect(dotEnv.contents).toMatch(/^POSTGRES_URI=/m);
+    expect(dotEnv.contents).toMatch(/^REDIS_URI=/m);
   });
 
   it("pins skein-js to the range it was told to", () => {

--- a/packages/create-skein-js/src/project-files.ts
+++ b/packages/create-skein-js/src/project-files.ts
@@ -44,6 +44,7 @@ function templateValuesFor(options: ScaffoldOptions): TemplateValues {
     apiKeyEnvVar: provider?.apiKeyEnvVar ?? "",
     providerConsoleUrl: provider?.consoleUrl ?? "",
     runDev: runCommand(options, "dev"),
+    runDevPostgres: runCommand(options, "dev:postgres"),
     runServices: runCommand(options, "dev:services"),
     runBuild: runCommand(options, "build"),
     runStart: runCommand(options, "start"),
@@ -60,9 +61,15 @@ function templateValuesFor(options: ScaffoldOptions): TemplateValues {
  */
 export function buildProjectFiles(options: ScaffoldOptions): readonly GeneratedFile[] {
   const values = templateValuesFor(options);
-  const fromTemplate = (templateKey: string, outputPath: string): GeneratedFile => ({
+  // `extras` is for the one thing a single shared value map cannot express: the same template
+  // rendered twice, differing per output file. Only `.env`/`.env.example` need it — see below.
+  const fromTemplate = (
+    templateKey: string,
+    outputPath: string,
+    extras: TemplateValues = {},
+  ): GeneratedFile => ({
     path: outputPath,
-    contents: renderTemplate(templateKey, values),
+    contents: renderTemplate(templateKey, { ...values, ...extras }),
   });
 
   const files: GeneratedFile[] = [
@@ -73,12 +80,17 @@ export function buildProjectFiles(options: ScaffoldOptions): readonly GeneratedF
     // The template is `gitignore.tmpl`, not `.gitignore.tmpl`: npm rewrites a `.gitignore` inside a
     // published tarball, which would silently ship a broken template.
     fromTemplate("gitignore", ".gitignore"),
-    fromTemplate("env.example", ".env.example"),
-    // The same contents, written twice on purpose. `langgraph.json` points at `.env`, so without it
-    // the very first `skein dev` opens with a warning about a missing file — a confusing way to greet
-    // someone whose project is working fine. Every line in it is commented out, and `.gitignore`
-    // excludes it, so this commits nothing and changes no behaviour.
-    { ...fromTemplate("env.example", ".env"), preserveIfPresent: true },
+    fromTemplate("env.example", ".env.example", { isEnvExample: true }),
+    // One template, written twice on purpose. `langgraph.json` points at `.env`, so without it the
+    // very first `skein dev` opens with a warning about a missing file — a confusing way to greet
+    // someone whose project is working fine. `.gitignore` excludes it, so this commits nothing.
+    //
+    // `isEnvExample` is what keeps the header honest: the two files were byte-identical, so the one
+    // that *is* `.env` opened by telling you to copy it to `.env`.
+    {
+      ...fromTemplate("env.example", ".env", { isEnvExample: false }),
+      preserveIfPresent: true,
+    },
     // Always emitted, not gated behind a flag: `skein start` is durable-only, so without this the
     // `start` script the project ships would be a trap.
     fromTemplate("compose.dev.yaml", "compose.dev.yaml"),

--- a/packages/create-skein-js/src/render-template.test.ts
+++ b/packages/create-skein-js/src/render-template.test.ts
@@ -37,6 +37,11 @@ describe("renderTemplate", () => {
       apiKeyEnvVar: "K",
       modelEnvVar: "M",
       defaultModel: "m",
+      // `env.example` renders twice, once per output file, and names the run commands it points at.
+      // Unsupplied names throw by design (see the note on `renderTemplate`), so they belong here.
+      isEnvExample: true,
+      runServices: "npm run dev:services",
+      runDevPostgres: "npm run dev:postgres",
     };
     const withoutProvider = { ...withProvider, hasProvider: false };
 

--- a/packages/create-skein-js/src/templates.generated.ts
+++ b/packages/create-skein-js/src/templates.generated.ts
@@ -48,7 +48,13 @@ services:
 volumes:
   postgres-data:
 `,
-  "env.example": `# Copy this file to .env and fill in what you need.
+  "env.example": `<%_ if (isEnvExample) { _%>
+# Copy this file to \`.env\` and fill in what you need. \`.env\` is gitignored, so a fresh clone of this
+# project has this file and not that one — this is the copy you start from.
+<%_ } else { _%>
+# This project's local environment, written for you when the project was scaffolded. Nothing to copy:
+# this *is* \`.env\`. (\`.env.example\` is the committed copy, for anyone cloning this repo.)
+<%_ } _%>
 # \`skein dev\` needs none of it: the \`echo\` graph runs with no credentials and no services.
 
 <%_ if (hasProvider) { _%>
@@ -62,11 +68,12 @@ volumes:
 
 <%_ } _%>
 # ---------------------------------------------------------------------------
-# Required by \`skein start\` — the production entrypoint is durable-only.
-# Run \`docker compose -f compose.dev.yaml up -d\` to get both locally.
+# Used by \`skein start\` and \`<%= runDevPostgres %>\`, both of which are durable-only.
+# These are already the right values for the \`compose.dev.yaml\` in this project — bring it up with
+# \`<%= runServices %>\`. Nothing reads them until you do; \`skein dev\` stays in memory regardless.
 # ---------------------------------------------------------------------------
-# POSTGRES_URI=postgresql://postgres:postgres@localhost:5432/skein
-# REDIS_URI=redis://localhost:6379
+POSTGRES_URI=postgresql://postgres:postgres@localhost:5432/skein
+REDIS_URI=redis://localhost:6379
 `,
   gitignore: `node_modules/
 dist/
@@ -110,6 +117,14 @@ An [Agent Protocol](https://github.com/langchain-ai/agent-protocol) server for y
 In-memory drivers, nothing to install or start. Edit a graph and save — the server hot-reloads and
 keeps your threads. Stop and restart it and your state is restored from \`.skein/\`.
 
+To develop against the drivers production runs on instead — same hot reload, state in Postgres and
+Redis rather than \`.skein/\`:
+
+\`\`\`bash
+<%= runServices %>   # Postgres + Redis
+<%= runDevPostgres %>
+\`\`\`
+
 ## What's in here
 
 - **\`src/echo-graph.ts\`** — a LangGraph.js graph that echoes your message back. No API key, no
@@ -118,7 +133,8 @@ keeps your threads. Stop and restart it and your state is restored from \`.skein
 - **\`src/agent-graph.ts\`** — a ReAct agent with a live weather tool. Needs a model key.
 <%_ } _%>
 - **\`langgraph.json\`** — points skein at your graphs. The same format the LangGraph CLI reads.
-- **\`.env.example\`** — copy to \`.env\`. Nothing in it is needed for \`dev\`.
+- **\`.env\`** — already in place, nothing to copy. Nothing in it is needed for \`dev\`.
+  (\`.env.example\` is the committed reference copy; \`.env\` itself is gitignored.)
 - **\`compose.dev.yaml\`** — Postgres and Redis, which \`start\` needs.
 - **\`tsconfig.json\`** — strict TypeScript, ESM.
 
@@ -127,7 +143,7 @@ keeps your threads. Stop and restart it and your state is restored from \`.skein
 
 The \`echo\` graph runs with no credentials. The \`agent\` graph needs \`<%= apiKeyEnvVar %>\`:
 
-\`.env\` is already here, with every line commented out. Uncomment one:
+\`.env\` is already here, with the model lines commented out. Uncomment one:
 
 \`\`\`bash
 # <%= apiKeyEnvVar %>=your-key-here     ← get one at <%= providerConsoleUrl %>
@@ -161,10 +177,12 @@ bundle with no TypeScript toolchain in the loop. That pair is exactly what the p
 
 \`\`\`bash
 <%= runServices %>   # Postgres + Redis
-# then uncomment POSTGRES_URI and REDIS_URI in .env
 <%= runBuild %>
 <%= runStart %>
 \`\`\`
+
+Nothing to edit first: \`.env\` already carries the \`POSTGRES_URI\` and \`REDIS_URI\` that match the
+\`compose.dev.yaml\` above, and \`skein dev\` ignores them either way.
 
 \`skein start\` is durable-only: it expects \`POSTGRES_URI\` and \`REDIS_URI\`, because that is what makes
 runs survive a restart and lets you run more than one instance. For a container instead,

--- a/packages/create-skein-js/templates/README.md.tmpl
+++ b/packages/create-skein-js/templates/README.md.tmpl
@@ -16,6 +16,14 @@ An [Agent Protocol](https://github.com/langchain-ai/agent-protocol) server for y
 In-memory drivers, nothing to install or start. Edit a graph and save — the server hot-reloads and
 keeps your threads. Stop and restart it and your state is restored from `.skein/`.
 
+To develop against the drivers production runs on instead — same hot reload, state in Postgres and
+Redis rather than `.skein/`:
+
+```bash
+<%= runServices %>   # Postgres + Redis
+<%= runDevPostgres %>
+```
+
 ## What's in here
 
 - **`src/echo-graph.ts`** — a LangGraph.js graph that echoes your message back. No API key, no
@@ -24,7 +32,8 @@ keeps your threads. Stop and restart it and your state is restored from `.skein/
 - **`src/agent-graph.ts`** — a ReAct agent with a live weather tool. Needs a model key.
 <%_ } _%>
 - **`langgraph.json`** — points skein at your graphs. The same format the LangGraph CLI reads.
-- **`.env.example`** — copy to `.env`. Nothing in it is needed for `dev`.
+- **`.env`** — already in place, nothing to copy. Nothing in it is needed for `dev`.
+  (`.env.example` is the committed reference copy; `.env` itself is gitignored.)
 - **`compose.dev.yaml`** — Postgres and Redis, which `start` needs.
 - **`tsconfig.json`** — strict TypeScript, ESM.
 
@@ -33,7 +42,7 @@ keeps your threads. Stop and restart it and your state is restored from `.skein/
 
 The `echo` graph runs with no credentials. The `agent` graph needs `<%= apiKeyEnvVar %>`:
 
-`.env` is already here, with every line commented out. Uncomment one:
+`.env` is already here, with the model lines commented out. Uncomment one:
 
 ```bash
 # <%= apiKeyEnvVar %>=your-key-here     ← get one at <%= providerConsoleUrl %>
@@ -67,10 +76,12 @@ bundle with no TypeScript toolchain in the loop. That pair is exactly what the p
 
 ```bash
 <%= runServices %>   # Postgres + Redis
-# then uncomment POSTGRES_URI and REDIS_URI in .env
 <%= runBuild %>
 <%= runStart %>
 ```
+
+Nothing to edit first: `.env` already carries the `POSTGRES_URI` and `REDIS_URI` that match the
+`compose.dev.yaml` above, and `skein dev` ignores them either way.
 
 `skein start` is durable-only: it expects `POSTGRES_URI` and `REDIS_URI`, because that is what makes
 runs survive a restart and lets you run more than one instance. For a container instead,

--- a/packages/create-skein-js/templates/env.example.tmpl
+++ b/packages/create-skein-js/templates/env.example.tmpl
@@ -1,4 +1,10 @@
-# Copy this file to .env and fill in what you need.
+<%_ if (isEnvExample) { _%>
+# Copy this file to `.env` and fill in what you need. `.env` is gitignored, so a fresh clone of this
+# project has this file and not that one — this is the copy you start from.
+<%_ } else { _%>
+# This project's local environment, written for you when the project was scaffolded. Nothing to copy:
+# this *is* `.env`. (`.env.example` is the committed copy, for anyone cloning this repo.)
+<%_ } _%>
 # `skein dev` needs none of it: the `echo` graph runs with no credentials and no services.
 
 <%_ if (hasProvider) { _%>
@@ -12,8 +18,9 @@
 
 <%_ } _%>
 # ---------------------------------------------------------------------------
-# Required by `skein start` — the production entrypoint is durable-only.
-# Run `docker compose -f compose.dev.yaml up -d` to get both locally.
+# Used by `skein start` and `<%= runDevPostgres %>`, both of which are durable-only.
+# These are already the right values for the `compose.dev.yaml` in this project — bring it up with
+# `<%= runServices %>`. Nothing reads them until you do; `skein dev` stays in memory regardless.
 # ---------------------------------------------------------------------------
-# POSTGRES_URI=postgresql://postgres:postgres@localhost:5432/skein
-# REDIS_URI=redis://localhost:6379
+POSTGRES_URI=postgresql://postgres:postgres@localhost:5432/skein
+REDIS_URI=redis://localhost:6379

--- a/scripts/scaffold-smoke.mjs
+++ b/scripts/scaffold-smoke.mjs
@@ -21,6 +21,11 @@ import path from "node:path";
 const scaffolder = path.resolve("packages/create-skein-js/dist/index.js");
 const providers = ["none", "anthropic"];
 
+/** Whether a Docker daemon is reachable — the durable half of this script needs one. */
+function dockerIsAvailable() {
+  return spawnSync("docker", ["info"], { stdio: "ignore", shell: false }).status === 0;
+}
+
 /** Run a command, streaming output, and fail the script if it exits non-zero. */
 function run(command, args, options = {}) {
   const label = `${command} ${args.join(" ")}`;
@@ -151,6 +156,90 @@ async function smokeTest(provider, port, ownVersion) {
   }
 }
 
+/**
+ * The other half of the generated README: `dev:services` → `build` → `start`.
+ *
+ * `dev` was the only thing this script exercised, so `start` being broken passed every check — it
+ * resolved `langgraph.json` from the cwd and died on the missing `schemas.json`, before it ever
+ * looked at `POSTGRES_URI`. Run verbatim, as a stranger following the README would: no exported
+ * variables and no hand-edited `.env`, because needing either is the bug.
+ *
+ * Provider-independent, so it runs once rather than per provider — the durable path does not touch
+ * the model. Skipped without a Docker daemon so the `dev` half still runs on a machine that has none.
+ */
+async function shipItSmokeTest(port, ownVersion) {
+  if (!dockerIsAvailable()) {
+    process.stdout.write("\nNo Docker daemon; skipping the `start` half of the smoke test.\n");
+    return;
+  }
+
+  const workspace = mkdtempSync(path.join(tmpdir(), "skein-scaffold-ship-"));
+  const project = path.join(workspace, "my-agent");
+  process.stdout.write(`\n=== ship it (dev:services → build → start) → ${project} ===\n`);
+
+  try {
+    run("node", [scaffolder, "my-agent", "--provider", "none", "--no-install", "--no-git", "-y"], {
+      cwd: workspace,
+    });
+    useAPublishedSkein(project, ownVersion);
+    run("npm", ["install", "--no-audit", "--no-fund"], { cwd: project });
+
+    // Inside the try, so the finally below tears the containers down even if compose itself fails
+    // partway. The workspace holding `compose.dev.yaml` is deleted straight after, so a leaked
+    // container could not be cleaned up by hand afterwards.
+    try {
+      run("npm", ["run", "dev:services"], { cwd: project });
+      run("npm", ["run", "build"], { cwd: project });
+
+      // `PORT` rather than a flag: `skein start` reads it, and the scaffolded script takes no args.
+      //
+      // The two URIs are passed explicitly, and only because this script installs the *published*
+      // `skein-js` on purpose. Reading them from the project's own `.env` — which is what makes the
+      // generated README's steps work with nothing to edit — needs `skein start` to read a
+      // conventional `.env` from its working directory, and the released CLI predates that. They
+      // match `compose.dev.yaml`, and the ambient environment outranks `.env` either way, so this
+      // changes nothing about what is under test here: that `build` produces an artifact and the
+      // scaffolded `start` script actually serves it. The `.env` half is covered by
+      // `packages/cli/src/project-env.test.ts`. Drop these two lines once the fix is released.
+      const server = spawn("npm", ["start"], {
+        cwd: project,
+        stdio: "inherit",
+        shell: false,
+        env: {
+          ...process.env,
+          PORT: String(port),
+          POSTGRES_URI: "postgresql://postgres:postgres@localhost:5432/skein",
+          REDIS_URI: "redis://localhost:6379",
+        },
+      });
+      // Raced against readiness below: a `start` that exits immediately is the exact failure this
+      // test exists to catch, and without this it would be reported as a 120s readiness timeout
+      // instead of as the exit code it actually was.
+      const crashed = new Promise((_resolve, reject) => {
+        server.once("exit", (code, signal) => {
+          if (signal === "SIGTERM") return; // our own teardown, below
+          reject(new Error(`\`npm start\` exited early (code ${code}, signal ${signal})`));
+        });
+      });
+      try {
+        const baseUrl = `http://127.0.0.1:${port}`;
+        await Promise.race([waitForServer(baseUrl, 120), crashed]);
+        await callTheServer(baseUrl);
+        process.stdout.write("\n✓ ship it: built an artifact and served a run from it\n");
+      } finally {
+        const exited = new Promise((resolve) => server.once("exit", resolve));
+        server.kill("SIGTERM");
+        await Promise.race([exited, new Promise((resolve) => setTimeout(resolve, 15_000))]);
+      }
+    } finally {
+      // Volumes too: a leftover Postgres volume would carry state into the next run of this script.
+      run("docker", ["compose", "-f", "compose.dev.yaml", "down", "-v"], { cwd: project });
+    }
+  } finally {
+    rmSync(workspace, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 });
+  }
+}
+
 // Sanity-check that the scaffolder pins the version it was built at, so a stale `dist/` cannot make
 // the rest of this pass against the wrong runtime.
 const ownVersion = JSON.parse(
@@ -162,5 +251,7 @@ let port = 2400;
 for (const provider of providers) {
   await smokeTest(provider, (port += 1), ownVersion);
 }
+
+await shipItSmokeTest((port += 1), ownVersion);
 
 process.stdout.write("\nAll scaffold smoke tests passed.\n");


### PR DESCRIPTION
Fixes #17. Bottom of a 2-PR stack; #43 sits on top.

A scaffolded project shipped Postgres and Redis wiring that could not connect, and a `start` script
that failed before it ever looked at it.

## What was broken

1. **`npm start` died on `no schemas.json next to the config`.** `skein start` serves a *build*, so it
   wants the artifact's own `langgraph.json`; the script ran a bare `skein start`, which resolves
   `langgraph.json` from the cwd. The artifact lives in `.skein/build`. **The issue does not mention
   this** — it reports `start` failing on the missing URIs, but it never got that far.
2. **`POSTGRES_URI` / `REDIS_URI` were commented out**, so the README told you to hand-edit a file in
   the middle of the documented happy path. The values match the `compose.dev.yaml` the scaffolder
   itself emits, so there was nothing to decide.
3. **No script exposed `skein dev --store postgres --queue redis`.** Added as `dev:postgres`.
4. **`.env` and `.env.example` were byte-identical**, so the file that *is* `.env` opened with
   "Copy this file to .env". They now differ in the header only — and `.env.example` keeps the copy
   instruction, because a fresh clone gets that file and not the gitignored one.

## The one CLI change

`skein start` now reads a conventional `.env` from its **working directory** as well as from the
config's, at the lowest precedence (below the artifact's own, below ambient).

This was scoped out initially, and I came back to it: without it the fix is not portable. The artifact
deliberately carries no `.env` — it is the Docker build context, and `write-manifest` drops a file
`env` for the same reason — so the script has to load one itself, and every way to do that fails
somewhere. `node --env-file-if-exists=… node_modules/skein-js/dist/index.js` breaks under Yarn PnP
(yarn is an offered `--pm`) and when `node_modules` is hoisted to a workspace root, and
`--env-file-if-exists` landed in Node 20.12 while every package declares `engines.node: ">=20"`.
`NODE_OPTIONS` rejects the flag outright. With the CLI reading the cwd, the scaffolded script is a
plain `skein start -c .skein/build/langgraph.json` and works everywhere.

Ambient still wins, so the `export POSTGRES_URI=… && skein start` that `docs/deploy.md` documents is
unaffected, and a platform-injected secret still outranks a file lying next to the code.

## Also

`dev:services` gained `--wait`. Without it compose returns once the containers are *created*, and the
newly documented `dev:services && build && start` chain races first-boot `initdb`.

## Tests

`packages/cli/src/project-env.test.ts` is new — precedence in both directions, the no-op when the two
directories coincide, and that ambient is never clobbered. `packages/create-skein-js` asserts the
uncommented URIs, the two headers, and the new scripts.

The `scaffold-smoke` CI job exercised `dev` only, which is exactly why `start` being broken passed
every check. It now also builds an artifact and serves a run from it — tearing containers down
(volumes included) in a `finally`, and racing the server's own exit against the readiness poll so a
crashed `start` reports its exit code rather than a 120s timeout. Skipped without a Docker daemon so
the `dev` half still runs. It passes the two URIs explicitly for now, because it installs the
*published* CLI on purpose and the released one predates the fix above; that comment says to drop them
once released.

## Verified by hand

In a scaffolded project, the generated README's steps run verbatim with nothing edited:
`dev:services` → `build` → `start` serves `echo: ship-it` against Postgres and Redis, and
`dev:postgres` boots against the same services reporting `state persists in postgres/redis`.