### PR TITLE
feat(create-skein-js): prompt for install, git and dev storage, and report what git did

### DIFF
--- a/docs/scaffolding.md
+++ b/docs/scaffolding.md
@@ -43,15 +43,23 @@ my-agent/
 
 The scripts are the whole skein CLI lifecycle:
 
-| Script         | Command                                      | What it does                                                |
-| -------------- | -------------------------------------------- | ----------------------------------------------------------- |
-| `dev`          | `skein dev --port 2024`                      | In-memory drivers, hot reload, state persisted to `.skein/` |
-| `dev:services` | `docker compose -f compose.dev.yaml up -d`   | Postgres + Redis, for `dev:postgres` and `start`            |
-| `dev:postgres` | `skein dev … --store postgres --queue redis` | The same hot reload, against the drivers production uses    |
-| `build`        | `skein build --artifact-only`                | Graphs → plain JavaScript in `.skein/build`                 |
-| `start`        | `skein start -c .skein/build/langgraph.json` | Serve that build — the production entrypoint                |
-| `typecheck`    | `tsc --noEmit`                               |                                                             |
-| `test`         | `vitest run`                                 |                                                             |
+| Script         | Command                                           | What it does                                                |
+| -------------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| `dev`          | `skein dev --port 2024`                           | In-memory drivers, hot reload, state persisted to `.skein/` |
+| `dev:services` | `docker compose -f compose.dev.yaml up -d --wait` | Postgres + Redis, for the durable `dev` and for `start`     |
+| `dev:postgres` | `skein dev … --store postgres --queue redis`      | The same hot reload, against the drivers production uses    |
+| `build`        | `skein build --artifact-only`                     | Graphs → plain JavaScript in `.skein/build`                 |
+| `start`        | `skein start -c .skein/build/langgraph.json`      | Serve that build — the production entrypoint                |
+| `typecheck`    | `tsc --noEmit`                                    |                                                             |
+| `test`         | `vitest run`                                      |                                                             |
+
+That is the in-memory axis, which is the default. The storage prompt decides only which of the two
+`dev` spellings is which: pick Postgres and `dev` becomes the durable one, with the in-memory one
+emitted as `dev:memory` instead of `dev:postgres`. Both are always on disk, so the choice sets a
+default rather than removing an option.
+
+`dev:services` uses `--wait` so it returns once both healthchecks pass, not merely once the containers
+exist — otherwise the very next command races first-boot `initdb`.
 
 `start` names the artifact's own `langgraph.json` because `skein start` serves a _build_, not a source
 project: it wants `schemas.json` beside the config it loads, and that file only exists in
@@ -77,8 +85,8 @@ create-skein-js [directory]
 
   -m, --provider <name>   none | google | anthropic | openai   (default: prompted, else none)
       --pm <name>         npm | pnpm | yarn | bun              (default: detected)
-      --no-install        Skip installing dependencies
-      --no-git            Skip initializing a git repository
+      --no-install        Skip installing dependencies                (else: prompted, default yes)
+      --no-git            Skip initializing a git repository          (else: prompted)
   -y, --yes               Accept every default; never prompt
   -f, --force             Scaffold into a directory that is not empty
   -v, --version
@@ -118,7 +126,10 @@ Until the key is set, `agent` fails to load naming the variable it wants — a
 - **Scaffolding into a fresh clone works.** A directory holding only `.git`, `LICENSE`, editor
   folders or `.DS_Store` counts as empty, so "create an empty repo, clone it, scaffold into it" needs
   no `--force`.
-- **git is skipped inside an existing work tree**, so it never nests a repository in yours.
+- **git is skipped inside an existing work tree**, so it never nests a repository in yours — and the
+  closing output says so, rather than leaving you to infer it from a missing `.git`. A failure (git
+  absent, or no `user.email` configured) is reported too, and distinctly: the two used to be the same
+  silent non-event.
 - **The version is pinned to a matching runtime.** Because every `packages/*` shares one version,
   `create-skein-js@x.y.z` pins `skein-js@^x.y.z` — the scaffolder and the runtime it scaffolds are
   always the same release.

--- a/docs/your-first-agent.md
+++ b/docs/your-first-agent.md
@@ -65,13 +65,16 @@ skein is a drop-in for it.
 
 **`package.json`** — the commands that are the whole lifecycle:
 
-|                        |                                                              |
-| ---------------------- | ------------------------------------------------------------ |
-| `npm run dev`          | what you're running: hot reload, in-memory state, zero setup |
-| `npm run dev:services` | Postgres + Redis in Docker, for `dev:postgres` and `start`   |
-| `npm run dev:postgres` | the same hot reload, against those services instead          |
-| `npm run build`        | compile your graphs to plain JavaScript in `.skein/`         |
-| `npm start`            | serve that build — this is what production runs              |
+|                        |                                                               |
+| ---------------------- | ------------------------------------------------------------- |
+| `npm run dev`          | what you're running: hot reload, in-memory state, zero setup  |
+| `npm run dev:services` | Postgres + Redis in Docker, for the durable `dev` and `start` |
+| `npm run dev:postgres` | the same hot reload, against those services instead           |
+| `npm run build`        | compile your graphs to plain JavaScript in `.skein/`          |
+| `npm start`            | serve that build — this is what production runs               |
+
+(If you picked Postgres at the storage prompt, `dev` is already the durable one and the in-memory
+spelling is `dev:memory` instead — both are always there.)
 
 The rest: `.env` (ready to use — the model key is commented out, the service URIs are not) and
 `.env.example` (a committed reference copy of it), `compose.dev.yaml` (the services for `start`),

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1521,13 +1521,16 @@ skein is a drop-in for it.
 
 **`package.json`** — the commands that are the whole lifecycle:
 
-|                        |                                                              |
-| ---------------------- | ------------------------------------------------------------ |
-| `npm run dev`          | what you're running: hot reload, in-memory state, zero setup |
-| `npm run dev:services` | Postgres + Redis in Docker, for `dev:postgres` and `start`   |
-| `npm run dev:postgres` | the same hot reload, against those services instead          |
-| `npm run build`        | compile your graphs to plain JavaScript in `.skein/`         |
-| `npm start`            | serve that build — this is what production runs              |
+|                        |                                                               |
+| ---------------------- | ------------------------------------------------------------- |
+| `npm run dev`          | what you're running: hot reload, in-memory state, zero setup  |
+| `npm run dev:services` | Postgres + Redis in Docker, for the durable `dev` and `start` |
+| `npm run dev:postgres` | the same hot reload, against those services instead           |
+| `npm run build`        | compile your graphs to plain JavaScript in `.skein/`          |
+| `npm start`            | serve that build — this is what production runs               |
+
+(If you picked Postgres at the storage prompt, `dev` is already the durable one and the in-memory
+spelling is `dev:memory` instead — both are always there.)
 
 The rest: `.env` (ready to use — the model key is commented out, the service URIs are not) and
 `.env.example` (a committed reference copy of it), `compose.dev.yaml` (the services for `start`),
@@ -1975,15 +1978,23 @@ my-agent/
 
 The scripts are the whole skein CLI lifecycle:
 
-| Script         | Command                                      | What it does                                                |
-| -------------- | -------------------------------------------- | ----------------------------------------------------------- |
-| `dev`          | `skein dev --port 2024`                      | In-memory drivers, hot reload, state persisted to `.skein/` |
-| `dev:services` | `docker compose -f compose.dev.yaml up -d`   | Postgres + Redis, for `dev:postgres` and `start`            |
-| `dev:postgres` | `skein dev … --store postgres --queue redis` | The same hot reload, against the drivers production uses    |
-| `build`        | `skein build --artifact-only`                | Graphs → plain JavaScript in `.skein/build`                 |
-| `start`        | `skein start -c .skein/build/langgraph.json` | Serve that build — the production entrypoint                |
-| `typecheck`    | `tsc --noEmit`                               |                                                             |
-| `test`         | `vitest run`                                 |                                                             |
+| Script         | Command                                           | What it does                                                |
+| -------------- | ------------------------------------------------- | ----------------------------------------------------------- |
+| `dev`          | `skein dev --port 2024`                           | In-memory drivers, hot reload, state persisted to `.skein/` |
+| `dev:services` | `docker compose -f compose.dev.yaml up -d --wait` | Postgres + Redis, for the durable `dev` and for `start`     |
+| `dev:postgres` | `skein dev … --store postgres --queue redis`      | The same hot reload, against the drivers production uses    |
+| `build`        | `skein build --artifact-only`                     | Graphs → plain JavaScript in `.skein/build`                 |
+| `start`        | `skein start -c .skein/build/langgraph.json`      | Serve that build — the production entrypoint                |
+| `typecheck`    | `tsc --noEmit`                                    |                                                             |
+| `test`         | `vitest run`                                      |                                                             |
+
+That is the in-memory axis, which is the default. The storage prompt decides only which of the two
+`dev` spellings is which: pick Postgres and `dev` becomes the durable one, with the in-memory one
+emitted as `dev:memory` instead of `dev:postgres`. Both are always on disk, so the choice sets a
+default rather than removing an option.
+
+`dev:services` uses `--wait` so it returns once both healthchecks pass, not merely once the containers
+exist — otherwise the very next command races first-boot `initdb`.
 
 `start` names the artifact's own `langgraph.json` because `skein start` serves a _build_, not a source
 project: it wants `schemas.json` beside the config it loads, and that file only exists in
@@ -2009,8 +2020,8 @@ create-skein-js [directory]
 
   -m, --provider <name>   none | google | anthropic | openai   (default: prompted, else none)
       --pm <name>         npm | pnpm | yarn | bun              (default: detected)
-      --no-install        Skip installing dependencies
-      --no-git            Skip initializing a git repository
+      --no-install        Skip installing dependencies                (else: prompted, default yes)
+      --no-git            Skip initializing a git repository          (else: prompted)
   -y, --yes               Accept every default; never prompt
   -f, --force             Scaffold into a directory that is not empty
   -v, --version
@@ -2050,7 +2061,10 @@ Until the key is set, `agent` fails to load naming the variable it wants — a
 - **Scaffolding into a fresh clone works.** A directory holding only `.git`, `LICENSE`, editor
   folders or `.DS_Store` counts as empty, so "create an empty repo, clone it, scaffold into it" needs
   no `--force`.
-- **git is skipped inside an existing work tree**, so it never nests a repository in yours.
+- **git is skipped inside an existing work tree**, so it never nests a repository in yours — and the
+  closing output says so, rather than leaving you to infer it from a missing `.git`. A failure (git
+  absent, or no `user.email` configured) is reported too, and distinctly: the two used to be the same
+  silent non-event.
 - **The version is pinned to a matching runtime.** Because every `packages/*` shares one version,
   `create-skein-js@x.y.z` pins `skein-js@^x.y.z` — the scaffolder and the runtime it scaffolds are
   always the same release.

--- a/packages/create-skein-js/README.md
+++ b/packages/create-skein-js/README.md
@@ -25,13 +25,16 @@ No database, no Docker, and no API key — `echo` answers your first request imm
 
 A `langgraph.json` project driven by the `skein` CLI — the same lifecycle you ship with:
 
-| Command        | What it does                                                        |
-| -------------- | ------------------------------------------------------------------- |
-| `dev`          | In-memory drivers, hot reload, dev state persisted across restarts  |
-| `dev:services` | Postgres + Redis via Docker Compose, for `dev:postgres` and `start` |
-| `dev:postgres` | The same hot reload, against the drivers production uses            |
-| `build`        | Bundle the graphs to plain JavaScript in `.skein/build`             |
-| `start`        | Serve that bundle — the production entrypoint                       |
+| Command        | What it does                                                           |
+| -------------- | ---------------------------------------------------------------------- |
+| `dev`          | In-memory drivers, hot reload, dev state persisted across restarts     |
+| `dev:services` | Postgres + Redis via Docker Compose, for the durable `dev` and `start` |
+| `dev:postgres` | The same hot reload, against the drivers production uses               |
+| `build`        | Bundle the graphs to plain JavaScript in `.skein/build`                |
+| `start`        | Serve that bundle — the production entrypoint                          |
+
+Choosing Postgres at the storage prompt swaps the last two: `dev` becomes the durable spelling and
+the in-memory one is emitted as `dev:memory`. Both are always present either way.
 
 ...plus an echo graph that runs with no credentials, a test for it, an optional model-backed ReAct
 agent, and a README explaining every file.
@@ -43,14 +46,20 @@ create-skein-js [directory]
 
   -m, --provider <name>   none | google | anthropic | openai   (default: prompted)
       --pm <name>         npm | pnpm | yarn | bun              (default: detected)
-      --no-install        Skip installing dependencies
-      --no-git            Skip initializing a git repository
+      --no-install        Skip installing dependencies             (else: prompted, default yes)
+      --no-git            Skip initializing a git repository       (else: prompted)
   -y, --yes               Accept every default; never prompt
   -f, --force             Scaffold into a directory that is not empty
 ```
 
 Everything is prompted when the terminal is interactive, and defaulted when it is not — so this is
-safe to run in a Dockerfile or a CI job without hanging.
+safe to run in a Dockerfile or a CI job without hanging. Interactively that means five questions:
+directory, model provider, local development storage, whether to install, and whether to initialize a
+git repository. The last defaults to no inside an existing work tree, since nesting a repository in
+yours is never the intent — and whichever way it goes, the closing output says what git actually did.
+
+`--pm` stays a flag with no prompt: it is detected from `npm_config_user_agent`, so asking would be a
+question whose answer is already known.
 
 npm needs `--` before flags; `pnpm create` and `npx` do not:
 

--- a/packages/create-skein-js/src/git.test.ts
+++ b/packages/create-skein-js/src/git.test.ts
@@ -1,0 +1,94 @@
+// Git initialization, and specifically the three outcomes it can have.
+//
+// This file had no tests, and the function returned a bare boolean in which `false` meant both
+// "deliberately skipped, you are already in a repository" and "tried and failed". The caller threw
+// that boolean away, so a scaffolded project with no `.git` gave a user nothing to tell the two
+// apart — which is the whole of the reporting half of #18.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { initializeGitRepository, isInsideGitWorkTree, wouldNestInsideGitWorkTree } from "./git.js";
+
+let root: string;
+
+/** Commit identity, so `git commit` works on a machine with no global config (CI, containers). */
+const identity = [
+  "-c",
+  "user.name=skein test",
+  "-c",
+  "user.email=test@example.com",
+  "-c",
+  "commit.gpgsign=false",
+];
+
+beforeEach(() => {
+  // `realpath` via mkdtemp's own return is not enough on macOS, where /var is a symlink to /private
+  // — git reports the resolved path and a naive comparison of the two would not match.
+  root = mkdtempSync(path.join(tmpdir(), "skein-git-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("initializeGitRepository", () => {
+  it("initializes and commits in a plain directory", () => {
+    const project = path.join(root, "my-agent");
+    mkdirSync(project);
+
+    // The real function shells out without an identity, so seed one locally first — otherwise this
+    // asserts the state of the machine's git config rather than the code.
+    spawnSync("git", [...identity, "init", "-b", "main"], { cwd: project, stdio: "ignore" });
+    rmSync(path.join(project, ".git"), { recursive: true, force: true });
+
+    const outcome = initializeGitRepository(project);
+
+    // On a machine with no commit identity at all this is "failed", which is itself correct and
+    // reported — so accept either, and assert the thing that must never happen: a silent skip.
+    expect(outcome).not.toBe("skipped-existing-repo");
+    if (outcome === "initialized") expect(isInsideGitWorkTree(project)).toBe(true);
+  });
+
+  it("skips, distinguishably, inside an existing work tree", () => {
+    spawnSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    const nested = path.join(root, "apps", "my-agent");
+    mkdirSync(nested, { recursive: true });
+
+    // The outcome that used to be indistinguishable from a failure. Nesting a repository inside
+    // someone's monorepo is rarely what they meant, so skipping is the default — saying so is the fix.
+    expect(initializeGitRepository(nested)).toBe("skipped-existing-repo");
+  });
+
+  it("honours an explicit request to nest anyway", () => {
+    // The interactive prompt asks "Initialize a git repository anyway?" inside a work tree. Without
+    // this the answer "yes" did nothing at all and the output still reported a skip — a question
+    // whose yes is a no-op is worse than no question.
+    spawnSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+    const nested = path.join(root, "apps", "my-agent");
+    mkdirSync(nested, { recursive: true });
+
+    expect(initializeGitRepository(nested, { allowNested: true })).not.toBe(
+      "skipped-existing-repo",
+    );
+  });
+});
+
+describe("wouldNestInsideGitWorkTree", () => {
+  it("answers for a directory that does not exist yet", () => {
+    // The case the prompt default depends on: the question is asked before the project is written,
+    // and `git rev-parse` needs a directory it can actually enter. Walking up to the nearest
+    // existing ancestor is what stops every nested target from answering "not in a work tree".
+    spawnSync("git", ["init", "-b", "main"], { cwd: root, stdio: "ignore" });
+
+    expect(wouldNestInsideGitWorkTree(path.join(root, "apps", "not", "created", "yet"))).toBe(true);
+  });
+
+  it("is false under a plain directory", () => {
+    expect(wouldNestInsideGitWorkTree(path.join(root, "my-agent"))).toBe(false);
+  });
+});

--- a/packages/create-skein-js/src/git.ts
+++ b/packages/create-skein-js/src/git.ts
@@ -1,6 +1,8 @@
 // Initializing a git repository in the scaffolded project.
 
 import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
 
 /** Run a git command in `directory`, swallowing its output. Returns whether it succeeded. */
 function git(directory: string, ...args: string[]): boolean {
@@ -14,18 +16,60 @@ export function isInsideGitWorkTree(directory: string): boolean {
 }
 
 /**
+ * The nearest ancestor of `directory` that exists, or `directory` itself if it does.
+ *
+ * `git rev-parse` needs a directory it can `cd` into, and the git question has to be answerable
+ * *before* the project is written — that is when the user is asked about it, and when the default
+ * for that question is decided. Asking about a path that does not exist yet would answer "not in a
+ * work tree" for every nested target, which is precisely backwards inside someone's monorepo.
+ */
+function nearestExistingDirectory(directory: string): string {
+  let current = path.resolve(directory);
+  while (!existsSync(current)) {
+    const parent = path.dirname(current);
+    if (parent === current) return current; // filesystem root; give up rather than loop
+    current = parent;
+  }
+  return current;
+}
+
+/** Whether scaffolding into `directory` would land inside a repository that already exists. */
+export function wouldNestInsideGitWorkTree(directory: string): boolean {
+  return isInsideGitWorkTree(nearestExistingDirectory(directory));
+}
+
+/**
+ * What `initializeGitRepository` did.
+ *
+ * Three outcomes, not a boolean: `false` used to mean both "deliberately skipped, you are already in
+ * a repository" and "tried and failed", which is exactly the distinction someone staring at a
+ * project with no `.git` needs — and the caller could not report what it could not tell apart.
+ */
+export type GitOutcome = "initialized" | "skipped-existing-repo" | "failed";
+
+/**
  * Initialize a repository and make the first commit.
  *
- * Skipped entirely when the target is already inside a work tree — scaffolding into a clone is a
- * normal thing to do, and nesting a repository inside another is never what someone meant.
+ * Skipped by default when the target is already inside a work tree — scaffolding into a clone is a
+ * normal thing to do, and nesting a repository inside another is rarely what someone meant. Rarely,
+ * not never: `allowNested` exists because the interactive prompt offers exactly that choice, and a
+ * question whose "yes" silently did nothing would be worse than not asking. So the skip is the
+ * default, and an explicit answer overrides it.
  *
  * Every failure is non-fatal and reported by the return value: git may be missing, or present but
  * without `user.email` configured, and neither is a reason to fail a scaffold that has already
  * written every file successfully.
  */
-export function initializeGitRepository(projectDirectory: string): boolean {
-  if (isInsideGitWorkTree(projectDirectory)) return false;
-  if (!git(projectDirectory, "init", "-b", "main")) return false;
-  if (!git(projectDirectory, "add", "-A")) return false;
-  return git(projectDirectory, "commit", "-m", "chore: scaffold skein-js project");
+export function initializeGitRepository(
+  projectDirectory: string,
+  options: { allowNested?: boolean } = {},
+): GitOutcome {
+  if (options.allowNested !== true && isInsideGitWorkTree(projectDirectory)) {
+    return "skipped-existing-repo";
+  }
+  if (!git(projectDirectory, "init", "-b", "main")) return "failed";
+  if (!git(projectDirectory, "add", "-A")) return "failed";
+  return git(projectDirectory, "commit", "-m", "chore: scaffold skein-js project")
+    ? "initialized"
+    : "failed";
 }

--- a/packages/create-skein-js/src/index.ts
+++ b/packages/create-skein-js/src/index.ts
@@ -18,15 +18,16 @@ import { Command, InvalidArgumentError } from "@commander-js/extra-typings";
 
 import { bold, dim, red } from "./colors.js";
 import { writeFilesToDisk } from "./file-tree-writer.js";
-import { initializeGitRepository } from "./git.js";
+import { initializeGitRepository, wouldNestInsideGitWorkTree } from "./git.js";
 import { describeNextSteps } from "./next-steps.js";
 import { resolvePackageManager, runPackageManagerInstall } from "./package-manager.js";
 import { buildProjectFiles } from "./project-files.js";
-import { canPrompt, promptChoice, promptText } from "./prompt.js";
+import { canPrompt, promptChoice, promptConfirm, promptText } from "./prompt.js";
 import {
   isModelProvider,
   isPackageManagerName,
   toPackageName,
+  type DevStorage,
   type ModelProvider,
   type PackageManagerName,
   type ScaffoldOptions,
@@ -54,6 +55,16 @@ const PROVIDER_CHOICES = [
   { value: "anthropic", label: "Anthropic Claude", hint: "ANTHROPIC_API_KEY" },
   { value: "openai", label: "OpenAI", hint: "OPENAI_API_KEY" },
 ] as const satisfies readonly { value: ModelProvider; label: string; hint: string }[];
+
+/**
+ * `memory` first and marked the default: it is the zero-setup promise, and the one that needs no
+ * Docker. The other exists because `skein start` is durable-only, so "does my agent behave the same
+ * against Postgres?" is a question every project eventually asks.
+ */
+const STORAGE_CHOICES = [
+  { value: "memory", label: "In memory", hint: "zero setup — state in .skein/" },
+  { value: "postgres", label: "Postgres + Redis", hint: "matches production; needs Docker" },
+] as const satisfies readonly { value: DevStorage; label: string; hint: string }[];
 
 const program = new Command()
   .name("create-skein-js")
@@ -99,6 +110,30 @@ const program = new Command()
       const targetDirectory = path.resolve(process.cwd(), projectName);
       assertTargetDirectoryUsable(targetDirectory, { force: options.force });
 
+      const devStorage = interactive
+        ? await promptChoice(ask, "Local development storage?", STORAGE_CHOICES, "memory")
+        : "memory";
+
+      // Both of these have a flag already; the flag is the *override*, and its absence used to mean
+      // "assume yes" rather than "ask". Installing takes time, network and a `node_modules`, and git
+      // writes a commit — neither is something to do to someone's disk without offering the choice.
+      const install =
+        options.install &&
+        (!interactive || (await promptConfirm(ask, "Install dependencies?", true)));
+
+      // Defaulted from where the project will land, not from the cwd, and computed before the
+      // directory exists — see `wouldNestInsideGitWorkTree`. Inside an existing work tree the answer
+      // is no, because nesting a repository in someone's monorepo is never what they meant.
+      const alreadyInRepo = wouldNestInsideGitWorkTree(targetDirectory);
+      const git =
+        options.git &&
+        (!interactive ||
+          (await promptConfirm(
+            ask,
+            alreadyInRepo ? "Initialize a git repository anyway?" : "Initialize a git repository?",
+            !alreadyInRepo,
+          )));
+
       // "." means "here", so the project is named after the directory it lands in.
       const resolvedName =
         projectName === "." ? path.basename(targetDirectory) : path.basename(projectName);
@@ -109,27 +144,38 @@ const program = new Command()
         packageName,
         provider,
         packageManager: options.pm ?? resolvePackageManager(process.env["npm_config_user_agent"]),
+        devStorage,
         skeinVersionRange: resolveSkeinVersionRange(),
       };
 
       writeFilesToDisk(targetDirectory, buildProjectFiles(scaffoldOptions));
 
+      // Closed once every question has been asked, and before the slow work starts, so the install's
+      // streamed output is not competing with an open readline.
       readline?.close();
 
       const installed =
-        options.install &&
-        runPackageManagerInstall(scaffoldOptions.packageManager, targetDirectory);
-      if (options.install && !installed) {
+        install && runPackageManagerInstall(scaffoldOptions.packageManager, targetDirectory);
+      if (install && !installed) {
         process.stdout.write(
           `\n${red("Install failed.")} ${dim("Your project is written — run it yourself below.")}\n`,
         );
       }
 
-      if (options.git) initializeGitRepository(targetDirectory);
+      // Reported, not discarded. A scaffold that quietly declines to create a repository — which is
+      // the right call inside an existing work tree — is indistinguishable from one where git is
+      // missing or unconfigured, and both leave you looking at a project with no `.git`.
+      // `allowNested` only when the user was actually asked and said yes: answering "anyway?" with a
+      // yes has to produce a repository, or the question was theatre. Non-interactively the skip
+      // stands, because nothing there expressed an intent to nest.
+      const gitOutcome = git
+        ? initializeGitRepository(targetDirectory, { allowNested: interactive && alreadyInRepo })
+        : undefined;
 
       const lines = describeNextSteps(scaffoldOptions, {
         relativeDirectory: path.relative(process.cwd(), targetDirectory) || ".",
         installed,
+        ...(gitOutcome ? { git: gitOutcome } : {}),
         renamedPackageTo: packageName === resolvedName ? undefined : packageName,
       });
       process.stdout.write(`${lines.join("\n")}\n`);

--- a/packages/create-skein-js/src/next-steps.test.ts
+++ b/packages/create-skein-js/src/next-steps.test.ts
@@ -9,6 +9,7 @@ function optionsFor(overrides: Partial<ScaffoldOptions> = {}): ScaffoldOptions {
     packageName: "my-agent",
     provider: "none",
     packageManager: "pnpm",
+    devStorage: "memory",
     skeinVersionRange: "^0.14.0",
     ...overrides,
   };
@@ -73,5 +74,51 @@ describe("describeNextSteps", () => {
     }).join("\n");
     expect(renamed).toContain("my-agent");
     expect(renamed).toContain("package.json");
+  });
+});
+
+describe("what git actually did", () => {
+  it("says so when it skipped because you are already in a repository", () => {
+    // The outcome the scaffolder used to discard. It is the *correct* behaviour and the one most
+    // likely to be read as a bug, since all you see afterwards is a project with no `.git`.
+    const lines = describeNextSteps(optionsFor(), { ...outcome, git: "skipped-existing-repo" });
+
+    expect(lines.join("\n")).toMatch(/skipped git init/i);
+    expect(lines.join("\n")).toMatch(/already inside a git repository/i);
+  });
+
+  it("says so when it tried and failed", () => {
+    const lines = describeNextSteps(optionsFor(), { ...outcome, git: "failed" }).join("\n");
+
+    expect(lines).toMatch(/could not initialize/i);
+    // Actionable: the usual cause is an unconfigured identity, not a missing binary.
+    expect(lines).toMatch(/user\.email/);
+  });
+
+  it("stays quiet when it worked, or was never attempted", () => {
+    // Nothing to report: a repository exists and the next steps are the point of this output. Not a
+    // bare /git/ — the closing line links to skein-js.github.io, which would match it.
+    const initialized = describeNextSteps(optionsFor(), { ...outcome, git: "initialized" }).join(
+      "\n",
+    );
+    expect(initialized).not.toMatch(/skipped git/i);
+    expect(initialized).not.toMatch(/could not initialize/i);
+    expect(describeNextSteps(optionsFor(), outcome).join("\n")).not.toMatch(/skipped git/i);
+  });
+});
+
+describe("the durable development axis", () => {
+  it("tells you to start the services before the dev server that needs them", () => {
+    const lines = describeNextSteps(optionsFor({ devStorage: "postgres" }), outcome);
+    const text = lines.join("\n");
+
+    expect(text).toContain("dev:services");
+    // Order matters more than presence: `dev` on this axis fails outright with nothing running.
+    expect(text.indexOf("dev:services")).toBeLessThan(text.indexOf("pnpm dev\n"));
+  });
+
+  it("says nothing about services on the in-memory axis", () => {
+    // The zero-setup promise: the default path must not mention Docker at all.
+    expect(describeNextSteps(optionsFor(), outcome).join("\n")).not.toContain("dev:services");
   });
 });

--- a/packages/create-skein-js/src/next-steps.ts
+++ b/packages/create-skein-js/src/next-steps.ts
@@ -5,6 +5,7 @@
 
 import { bold, cyan, dim, yellow } from "./colors.js";
 import { PROVIDER_DETAILS } from "./dependency-versions.js";
+import type { GitOutcome } from "./git.js";
 import type { ScaffoldOptions } from "./scaffold-options.js";
 
 /** What actually happened during the scaffold, which decides what still needs doing. */
@@ -13,6 +14,8 @@ export interface ScaffoldOutcome {
   readonly relativeDirectory: string;
   /** Whether dependencies are already installed. */
   readonly installed: boolean;
+  /** What git did, or `undefined` when it was not attempted (`--no-git`, or the user declined). */
+  readonly git?: GitOutcome;
   /** Set when the npm-legal package name had to differ from the directory name. */
   readonly renamedPackageTo?: string;
 }
@@ -39,6 +42,19 @@ export function describeNextSteps(
     );
   }
 
+  // Stated rather than left to be inferred from the absence of `.git`. Skipping inside an existing
+  // work tree is the *correct* behaviour and the one most likely to look like a bug, so it is the
+  // one that most needs saying.
+  if (outcome.git === "skipped-existing-repo") {
+    lines.push(`  ${dim("Skipped git init — this is already inside a git repository.")}`, "");
+  } else if (outcome.git === "failed") {
+    lines.push(
+      yellow("  Could not initialize a git repository."),
+      dim("  git may be missing, or have no user.name / user.email configured."),
+      "",
+    );
+  }
+
   if (outcome.relativeDirectory !== ".") {
     lines.push(`  ${cyan(`cd ${outcome.relativeDirectory}`)}`);
   }
@@ -57,6 +73,12 @@ export function describeNextSteps(
     lines.push(
       `  ${yellow(`Set ${provider.apiKeyEnvVar} in .env`)}   ${dim(`— uncomment it; get a key at ${provider.consoleUrl}`)}`,
     );
+  }
+  // On the durable axis `dev` needs Postgres and Redis, so the very first command we print would
+  // otherwise fail with nothing running. Listed as its own step for the same reason the API key is:
+  // a footnote after the URLs is a footnote people scroll past.
+  if (options.devStorage === "postgres") {
+    lines.push(`  ${cyan(runCommand(options, "dev:services"))}   ${dim("— Postgres + Redis")}`);
   }
   lines.push(`  ${cyan(runCommand(options, "dev"))}`, "");
 

--- a/packages/create-skein-js/src/package-manifest.ts
+++ b/packages/create-skein-js/src/package-manifest.ts
@@ -17,19 +17,24 @@ function sortedByKey(entries: Record<string, string>): Record<string, string> {
   return Object.fromEntries(Object.entries(entries).sort(([a], [b]) => a.localeCompare(b)));
 }
 
-function scriptsFor(): Record<string, string> {
+function scriptsFor(options: ScaffoldOptions): Record<string, string> {
+  const memory = "skein dev --port 2024";
+  const durable = `${memory} --store postgres --queue redis`;
+  const durableIsDefault = options.devStorage === "postgres";
   return {
     // The drop-in for `langgraph dev`: TypeScript loaded in-process, hot reload, and dev state
-    // persisted to .skein/ across restarts. Runs on in-memory drivers — nothing to install.
-    dev: "skein dev --port 2024",
-    // `start` and `dev:postgres` are durable-only, so this is what makes them runnable locally.
+    // persisted to .skein/ across restarts. In-memory by default — nothing to install, nothing to
+    // start — unless the scaffold was told to develop against durable drivers instead.
+    dev: durableIsDefault ? durable : memory,
+    // `start`, and `dev` on the durable axis, need these locally.
     // `--wait`, not a bare `up -d`: without it this returns once the containers are *created*, and
     // the documented `dev:services && build && start` chain then races first-boot `initdb`. The
     // compose file declares healthchecks for both services precisely so this can block on them.
     "dev:services": "docker compose -f compose.dev.yaml up -d --wait",
-    // Develop against the drivers production actually uses. The CLI has always supported this; no
-    // scaffolded script exposed it, so finding it meant finding flags the project never mentions.
-    "dev:postgres": "skein dev --port 2024 --store postgres --queue redis",
+    // Whichever spelling `dev` is not. Both are always emitted, so choosing one at scaffold time
+    // never takes the other away — and the durable one is otherwise a pair of flags the generated
+    // project never mentions, which is how "develop against Postgres" came to be undiscoverable.
+    ...(durableIsDefault ? { "dev:memory": memory } : { "dev:postgres": durable }),
     // `--artifact-only` stops at .skein/build instead of invoking Docker, so `build` + `start` work
     // on a machine with no Docker daemon. Drop the flag (or use `skein up`) to get an image.
     build: "skein build --artifact-only",
@@ -84,7 +89,7 @@ export function renderPackageManifest(options: ScaffoldOptions): string {
     version: "0.1.0",
     private: true,
     type: "module",
-    scripts: scriptsFor(),
+    scripts: scriptsFor(options),
     dependencies: dependenciesFor(options),
     devDependencies: devDependenciesFor(options),
   };

--- a/packages/create-skein-js/src/project-files.test.ts
+++ b/packages/create-skein-js/src/project-files.test.ts
@@ -22,6 +22,7 @@ function optionsFor(provider: ScaffoldOptions["provider"]): ScaffoldOptions {
     packageName: "my-agent",
     provider,
     packageManager: "pnpm",
+    devStorage: "memory",
     skeinVersionRange: "^0.14.0",
   };
 }
@@ -292,6 +293,8 @@ describe("the scripts a scaffolded project ships", () => {
     // Durable development, which the CLI always supported and no script exposed.
     expect(manifest.scripts["dev:postgres"]).toContain("--store postgres");
     expect(manifest.scripts["dev:postgres"]).toContain("--queue redis");
+    // In-memory by default, so `dev` needs nothing installed or started.
+    expect(manifest.scripts["dev"]).not.toContain("--store postgres");
 
     // `start` serves the *artifact*, so it must point at the artifact's own `langgraph.json`. A bare
     // `skein start` resolves `langgraph.json` from the cwd and dies on the missing `schemas.json`
@@ -336,5 +339,33 @@ describe("the scripts a scaffolded project ships", () => {
     ) as { devDependencies: Record<string, string> };
 
     expect(manifest.devDependencies["skein-js"]).toBe("^0.14.0");
+  });
+});
+
+describe("the local development storage axis", () => {
+  const scriptsFor = (devStorage: ScaffoldOptions["devStorage"]) =>
+    JSON.parse(
+      buildProjectFiles({ ...optionsFor("none"), devStorage }).find(
+        (file) => file.path === "package.json",
+      )!.contents,
+    ).scripts as Record<string, string>;
+
+  it("makes `dev` durable when asked, and keeps the in-memory spelling", () => {
+    const scripts = scriptsFor("postgres");
+
+    expect(scripts["dev"]).toContain("--store postgres --queue redis");
+    expect(scripts["dev:memory"]).toBe("skein dev --port 2024");
+    expect(scripts["dev:postgres"]).toBeUndefined();
+  });
+
+  it("never takes the other spelling away", () => {
+    // Choosing at scaffold time picks a default, not a capability: whichever way the axis goes, both
+    // commands are on disk, so nobody has to discover a pair of flags the project never mentions.
+    for (const storage of ["memory", "postgres"] as const) {
+      const scripts = scriptsFor(storage);
+      const both = [scripts["dev"], scripts["dev:memory"] ?? scripts["dev:postgres"]];
+      expect(both.filter((script) => script?.includes("--store postgres"))).toHaveLength(1);
+      expect(both.filter((script) => script === "skein dev --port 2024")).toHaveLength(1);
+    }
   });
 });

--- a/packages/create-skein-js/src/project-files.ts
+++ b/packages/create-skein-js/src/project-files.ts
@@ -1,8 +1,7 @@
 // The shared pure core: every file a scaffolded project consists of, as data.
 //
-// Pure and side-effect-free so it is trivially unit-testable and so both entry points can share it
-// verbatim — the `npm create` bin writes the result with node:fs, the Nx generator writes it through
-// devkit's virtual Tree. Same split as packages/cli/src/bundle/write-manifest.ts: pure builders
+// Pure and side-effect-free so it is trivially unit-testable: this returns the files, and the caller
+// writes them with node:fs. Same split as packages/cli/src/bundle/write-manifest.ts — pure builders
 // here, I/O in the caller.
 //
 // The file *contents* live in ../templates/**.tmpl and are compiled into templates.generated.ts at
@@ -44,7 +43,13 @@ function templateValuesFor(options: ScaffoldOptions): TemplateValues {
     apiKeyEnvVar: provider?.apiKeyEnvVar ?? "",
     providerConsoleUrl: provider?.consoleUrl ?? "",
     runDev: runCommand(options, "dev"),
-    runDevPostgres: runCommand(options, "dev:postgres"),
+    devIsDurable: options.devStorage === "postgres",
+    // Whichever spelling `dev` is not — `package-manifest` emits exactly one of the two, so naming
+    // the wrong one here would put a script in the README that is not in `package.json`.
+    runDevAlternate: runCommand(
+      options,
+      options.devStorage === "postgres" ? "dev:memory" : "dev:postgres",
+    ),
     runServices: runCommand(options, "dev:services"),
     runBuild: runCommand(options, "build"),
     runStart: runCommand(options, "start"),

--- a/packages/create-skein-js/src/prompt.test.ts
+++ b/packages/create-skein-js/src/prompt.test.ts
@@ -1,0 +1,68 @@
+// The prompt helpers, driven by a fake `ask` — the testability the module's own header promises.
+
+import { describe, expect, it } from "vitest";
+
+import { canPrompt, promptChoice, promptConfirm, promptText } from "./prompt.js";
+
+/** An `AskQuestion` that replays canned answers and records what it was asked. */
+function answering(...answers: string[]) {
+  const asked: string[] = [];
+  let next = 0;
+  return {
+    asked,
+    ask: async (query: string) => {
+      asked.push(query);
+      return answers[next++] ?? "";
+    },
+  };
+}
+
+describe("promptConfirm", () => {
+  it("accepts the spellings a person actually types", async () => {
+    for (const yes of ["y", "Y", "yes", "YES", " yes "]) {
+      expect(await promptConfirm(answering(yes).ask, "?", false)).toBe(true);
+    }
+    for (const no of ["n", "N", "no", "NO", " no "]) {
+      expect(await promptConfirm(answering(no).ask, "?", true)).toBe(false);
+    }
+  });
+
+  it("takes the default on an empty or unrecognised answer", async () => {
+    // Same forgiveness as `promptChoice`: a stray keystroke in the middle of a scaffold should not
+    // be an error, and the default is always the safe answer.
+    expect(await promptConfirm(answering("").ask, "?", true)).toBe(true);
+    expect(await promptConfirm(answering("").ask, "?", false)).toBe(false);
+    expect(await promptConfirm(answering("maybe").ask, "?", true)).toBe(true);
+    expect(await promptConfirm(answering("maybe").ask, "?", false)).toBe(false);
+  });
+
+  it("shows which way it will go if you just press enter", async () => {
+    const yesDefault = answering("");
+    await promptConfirm(yesDefault.ask, "Install dependencies?", true);
+    expect(yesDefault.asked[0]).toContain("Y/n");
+
+    const noDefault = answering("");
+    await promptConfirm(noDefault.ask, "Initialize a git repository?", false);
+    expect(noDefault.asked[0]).toContain("y/N");
+  });
+});
+
+describe("canPrompt", () => {
+  it("refuses when --yes was passed, whatever the terminal looks like", () => {
+    // The other two conditions are ambient (TTY, CI) and not ours to fake here; this is the one a
+    // caller controls, and the one that has to hold for `-y` to mean "never ask".
+    expect(canPrompt({ yes: true })).toBe(false);
+  });
+});
+
+describe("promptText and promptChoice still take their defaults", () => {
+  it("falls back on empty input", async () => {
+    expect(await promptText(answering("").ask, "Project directory", "my-agent")).toBe("my-agent");
+    const choices = [
+      { value: "memory", label: "In memory" },
+      { value: "postgres", label: "Postgres + Redis" },
+    ] as const;
+    expect(await promptChoice(answering("").ask, "Storage?", choices, "memory")).toBe("memory");
+    expect(await promptChoice(answering("2").ask, "Storage?", choices, "memory")).toBe("postgres");
+  });
+});

--- a/packages/create-skein-js/src/prompt.ts
+++ b/packages/create-skein-js/src/prompt.ts
@@ -40,6 +40,23 @@ export async function promptText(
   return trimmed === "" ? fallback : trimmed;
 }
 
+/**
+ * Ask a yes/no question. An empty answer, or anything unrecognised, takes `defaultValue` — same
+ * forgiveness as {@link promptChoice}, and for the same reason: a stray keystroke during a scaffold
+ * should not be an error, and the default is always the safe answer.
+ */
+export async function promptConfirm(
+  ask: AskQuestion,
+  question: string,
+  defaultValue: boolean,
+): Promise<boolean> {
+  const hint = defaultValue ? "Y/n" : "y/N";
+  const answer = (await ask(`${bold(question)} ${dim(`(${hint})`)} `)).trim().toLowerCase();
+  if (answer === "y" || answer === "yes") return true;
+  if (answer === "n" || answer === "no") return false;
+  return defaultValue;
+}
+
 /** One selectable option in {@link promptChoice}. */
 export interface PromptChoice<T extends string> {
   readonly value: T;

--- a/packages/create-skein-js/src/scaffold-options.ts
+++ b/packages/create-skein-js/src/scaffold-options.ts
@@ -1,7 +1,7 @@
 // The fully-resolved description of one scaffolded project. Everything that varies between two
-// generated projects lives here, and nothing else does — both entry points (the `npm create` bin and
-// the Nx `app` generator) reduce their very different inputs to this one shape before touching a
-// template. That is what keeps the two doors from drifting apart.
+// generated projects lives here, and nothing else does: the `npm create` bin reduces its flags and
+// prompts to this one shape before touching a template, so what a template can vary on is exactly
+// this interface and nothing ambient.
 //
 // There is deliberately no "template" or "framework" axis. A scaffolded project is a `langgraph.json`
 // driven by the skein CLI — `skein dev` to develop, `skein build` + `skein start` to ship. Mounting
@@ -10,20 +10,25 @@
 // adapter, not a starter: a scaffolder that emitted one would be generating an app rather than an
 // agent.
 //
-// There is no storage axis either, because the CLI lifecycle already fixes it: `skein dev` runs on
-// in-memory drivers with zero setup, and `skein start` is durable-only — it defaults to
-// `--store postgres --queue redis` and fails without POSTGRES_URI/REDIS_URI. Every scaffolded
-// project therefore ships the compose file that provides them, and the only real choice left is the
-// model provider.
+// There is one storage axis, and it is narrow: which drivers the generated `dev` script runs on.
+// The CLI lifecycle fixes everything else — `skein dev` runs on in-memory drivers with zero setup,
+// and `skein start` is durable-only (it defaults to `--store postgres --queue redis` and fails
+// without POSTGRES_URI/REDIS_URI), so every scaffolded project ships the compose file that provides
+// them either way. What the axis changes is only which of the two `dev` spellings is the default and
+// which is the alternate script; both are always emitted, so neither choice takes anything away.
 
 /** Which chat model the optional second graph is wired to. `none` emits no model graph at all. */
 export type ModelProvider = "none" | "google" | "anthropic" | "openai";
+
+/** Which drivers the generated `dev` script runs on. See {@link ScaffoldOptions.devStorage}. */
+export type DevStorage = "memory" | "postgres";
 
 /** Package managers we detect, emit instructions for, and can run an install with. */
 export type PackageManagerName = "npm" | "pnpm" | "yarn" | "bun";
 
 export const MODEL_PROVIDERS: readonly ModelProvider[] = ["none", "google", "anthropic", "openai"];
 export const PACKAGE_MANAGERS: readonly PackageManagerName[] = ["npm", "pnpm", "yarn", "bun"];
+export const DEV_STORAGES: readonly DevStorage[] = ["memory", "postgres"];
 
 /** Everything a template needs. Fully resolved — no defaults left to apply downstream. */
 export interface ScaffoldOptions {
@@ -34,6 +39,14 @@ export interface ScaffoldOptions {
   readonly provider: ModelProvider;
   /** Chosen or detected. Affects the install command and the instructions we print — nothing else. */
   readonly packageManager: PackageManagerName;
+  /**
+   * Which drivers the generated `dev` script runs on.
+   *
+   * `memory` is the zero-setup default and what the docs lead with. `postgres` makes `dev` the
+   * durable spelling for someone who wants local development to match production; the other
+   * spelling is still emitted, as `dev:memory` or `dev:postgres` respectively.
+   */
+  readonly devStorage: DevStorage;
   /**
    * The range emitted for `skein-js` and every `@skein-js/*` dependency, e.g. `^0.14.0`. Derived
    * from this package's own version: `nx release` runs a *fixed* group over `packages/*`, so the

--- a/packages/create-skein-js/src/templates.generated.ts
+++ b/packages/create-skein-js/src/templates.generated.ts
@@ -8,7 +8,7 @@
  */
 export const TEMPLATE_SOURCES: Readonly<Record<string, string>> = {
   "compose.dev.yaml": `# Local services for \`skein start\`, which is durable-only. Start them with:
-#   docker compose -f compose.dev.yaml up -d
+#   docker compose -f compose.dev.yaml up -d --wait
 # \`skein dev\` does not need them — it runs on in-memory drivers.
 
 services:
@@ -68,7 +68,7 @@ volumes:
 
 <%_ } _%>
 # ---------------------------------------------------------------------------
-# Used by \`skein start\` and \`<%= runDevPostgres %>\`, both of which are durable-only.
+# Used by \`skein start\`, and by the durable \`dev\` spelling — both need these two.
 # These are already the right values for the \`compose.dev.yaml\` in this project — bring it up with
 # \`<%= runServices %>\`. Nothing reads them until you do; \`skein dev\` stays in memory regardless.
 # ---------------------------------------------------------------------------
@@ -114,6 +114,17 @@ An [Agent Protocol](https://github.com/langchain-ai/agent-protocol) server for y
 - <http://localhost:2024> — the Agent Protocol API
 - <http://localhost:2024/console> — the console: threads, live runs, interrupt approvals, time travel
 
+<%_ if (devIsDurable) { _%>
+Postgres and Redis, the same drivers production runs on — start them with \`<%= runServices %>\` first.
+Edit a graph and save; the server hot-reloads and keeps your threads.
+
+For the zero-setup path instead — in-memory drivers, nothing to install or start, state restored from
+\`.skein/\` across restarts:
+
+\`\`\`bash
+<%= runDevAlternate %>
+\`\`\`
+<%_ } else { _%>
 In-memory drivers, nothing to install or start. Edit a graph and save — the server hot-reloads and
 keeps your threads. Stop and restart it and your state is restored from \`.skein/\`.
 
@@ -122,8 +133,9 @@ Redis rather than \`.skein/\`:
 
 \`\`\`bash
 <%= runServices %>   # Postgres + Redis
-<%= runDevPostgres %>
+<%= runDevAlternate %>
 \`\`\`
+<%_ } _%>
 
 ## What's in here
 

--- a/packages/create-skein-js/templates/README.md.tmpl
+++ b/packages/create-skein-js/templates/README.md.tmpl
@@ -13,6 +13,17 @@ An [Agent Protocol](https://github.com/langchain-ai/agent-protocol) server for y
 - <http://localhost:2024> — the Agent Protocol API
 - <http://localhost:2024/console> — the console: threads, live runs, interrupt approvals, time travel
 
+<%_ if (devIsDurable) { _%>
+Postgres and Redis, the same drivers production runs on — start them with `<%= runServices %>` first.
+Edit a graph and save; the server hot-reloads and keeps your threads.
+
+For the zero-setup path instead — in-memory drivers, nothing to install or start, state restored from
+`.skein/` across restarts:
+
+```bash
+<%= runDevAlternate %>
+```
+<%_ } else { _%>
 In-memory drivers, nothing to install or start. Edit a graph and save — the server hot-reloads and
 keeps your threads. Stop and restart it and your state is restored from `.skein/`.
 
@@ -21,8 +32,9 @@ Redis rather than `.skein/`:
 
 ```bash
 <%= runServices %>   # Postgres + Redis
-<%= runDevPostgres %>
+<%= runDevAlternate %>
 ```
+<%_ } _%>
 
 ## What's in here
 

--- a/packages/create-skein-js/templates/compose.dev.yaml.tmpl
+++ b/packages/create-skein-js/templates/compose.dev.yaml.tmpl
@@ -1,5 +1,5 @@
 # Local services for `skein start`, which is durable-only. Start them with:
-#   docker compose -f compose.dev.yaml up -d
+#   docker compose -f compose.dev.yaml up -d --wait
 # `skein dev` does not need them — it runs on in-memory drivers.
 
 services:

--- a/packages/create-skein-js/templates/env.example.tmpl
+++ b/packages/create-skein-js/templates/env.example.tmpl
@@ -18,7 +18,7 @@
 
 <%_ } _%>
 # ---------------------------------------------------------------------------
-# Used by `skein start` and `<%= runDevPostgres %>`, both of which are durable-only.
+# Used by `skein start`, and by the durable `dev` spelling — both need these two.
 # These are already the right values for the `compose.dev.yaml` in this project — bring it up with
 # `<%= runServices %>`. Nothing reads them until you do; `skein dev` stays in memory regardless.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #18. Top of a 2-PR stack — review #42 first; this one is based on it.

The scaffolder asked two questions — directory and model provider — then decided everything else
silently. Three of those silent decisions are now prompts, and the one that was invisible in both
directions is now reported.

## The prompts

- **Install** — `--no-install` existed but was never offered. Streaming npm's output makes it visible,
  not consented to; someone on a metered connection, or installing from a workspace root, had no
  chance to decline. Defaults to yes.
- **Git** — defaults to yes outside a work tree and **no inside one**. The default is computed from
  where the project will land, before the directory exists, so a nested target answers correctly
  rather than reporting "not in a work tree" for everything.
- **Local development storage** — memory (unchanged default) or Postgres + Redis. Choosing Postgres
  makes `dev` the durable spelling and emits the in-memory one as `dev:memory`. **Both are always on
  disk**, so the choice sets a default rather than removing an option. On that axis the closing steps
  list `dev:services` first, since `dev` will not start without it.

`--pm` stays flag-only, per the issue: it is detected from `npm_config_user_agent`, so asking would be
a question whose answer is already known.

## Report what git did

`initializeGitRepository` returned a boolean in which `false` meant both "skipped, you are already in
a repository" and "tried and failed" — the exact distinction someone looking at a project with no
`.git` needs — and `index.ts` discarded it anyway. It returns a three-way outcome now, and the closing
output states the skip ("Skipped git init — this is already inside a git repository") and the failure,
naming `user.email` as the usual cause.

One thing the issue does not anticipate: asking "Initialize a git repository **anyway**?" inside a work
tree needs the answer to be actionable. `initializeGitRepository` refused to nest unconditionally, so
a yes would have done nothing while the output still reported a skip. It takes `allowNested` now, set
only when the user was actually asked and said yes.

## Safety

Prompting is gated by the existing `canPrompt` — both streams a TTY, `--yes` absent, `CI` unset — so
this still cannot hang in a Dockerfile or a CI job. The readline is now closed after the last question
rather than before the first, which is what makes the new prompts reachable at all.

## Tests

`prompt.ts` and `git.ts` had **no tests at all**; both do now — the answer spellings people actually
type, the default-on-anything-else forgiveness, the three git outcomes, the nest-anyway path, and
`wouldNestInsideGitWorkTree` on a directory that does not exist yet.

Verified against the built binary: every prompt in order; the non-interactive path taking defaults
without hanging; `anyway? y` producing a real `.git` inside a work tree; `-y` inside one reporting the
skip; and the durable axis emitting `dev`/`dev:memory` with a README whose prose matches.