### PR TITLE
fix(redis): stop shipping untested majors of bullmq and ioredis

### DIFF
--- a/packages/runtime-redis/package.json
+++ b/packages/runtime-redis/package.json
@@ -43,8 +43,8 @@
   },
   "dependencies": {
     "@skein-js/core": "workspace:*",
-    "ioredis": ">=5.4.0",
-    "bullmq": ">=5.0.0"
+    "ioredis": "^5.4.0",
+    "bullmq": "^5.0.0"
   },
   "devDependencies": {
     "@skein-js/test-support": "workspace:*"

--- a/packages/runtime-redis/src/redis-connection.test.ts
+++ b/packages/runtime-redis/src/redis-connection.test.ts
@@ -1,0 +1,96 @@
+// `settleBullConnection` across BullMQ majors.
+//
+// This helper runs on the shutdown path, where it is the *last* thing that should ever throw. It read
+// `resource.client.then(...)` unconditionally, which is BullMQ 5's spelling; BullMQ 6 removed that
+// getter, so reading it yields `undefined` and every stop ended with
+// `Cannot read properties of undefined (reading 'then')` reported as an unclean shutdown.
+//
+// The manifest range said `>=5.0.0`, so a fresh `npm install` resolved BullMQ 6 and got exactly that.
+
+import { describe, expect, it } from "vitest";
+
+import { CONNECTION_SETTLE_TIMEOUT_MS, settleBullConnection } from "./redis-connection.js";
+
+describe("settleBullConnection", () => {
+  it("settles a BullMQ 5 resource through `client`", async () => {
+    let awaited = false;
+    await settleBullConnection({
+      client: Promise.resolve().then(() => {
+        awaited = true;
+      }),
+    });
+    expect(awaited).toBe(true);
+  });
+
+  it("settles a BullMQ 6 resource through `waitUntilReady()`", async () => {
+    let calls = 0;
+    await settleBullConnection({
+      waitUntilReady: async () => {
+        calls += 1;
+      },
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("is a no-op when the resource offers neither", async () => {
+    // The shape that used to throw. Settling is an optimisation over closing; the close that follows
+    // is what actually has to happen, so an unrecognised resource must not fail the shutdown.
+    await expect(settleBullConnection({})).resolves.toBeUndefined();
+    await expect(settleBullConnection({ client: undefined })).resolves.toBeUndefined();
+  });
+
+  it("swallows a rejected connection rather than failing teardown", async () => {
+    await expect(
+      settleBullConnection({ client: Promise.reject(new Error("ECONNREFUSED")) }),
+    ).resolves.toBeUndefined();
+    await expect(
+      settleBullConnection({
+        waitUntilReady: () => Promise.reject(new Error("ECONNREFUSED")),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("survives a resource that throws synchronously", async () => {
+    // A partly-constructed Queue or Worker throws straight out of the getter or the call. Letting
+    // that escape would skip the `close()` the caller runs next — the same shape as the bug this
+    // helper is being fixed for, just one level up.
+    await expect(
+      settleBullConnection({
+        waitUntilReady: () => {
+          throw new Error("backend is not ready");
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    await expect(
+      settleBullConnection(
+        Object.create(null, {
+          client: {
+            get() {
+              throw new Error("connection is undefined");
+            },
+          },
+        }) as { client?: Promise<unknown> },
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("prefers `waitUntilReady()` when a resource somehow has both", async () => {
+    // Defensive ordering: the newer spelling is the one that works on the newer major, and a v6
+    // resource carrying a vestigial `client` must not be settled through the dead one.
+    //
+    // Discriminated by a `client` that never settles: picking it would leave this to the 1s timeout,
+    // so finishing promptly is the assertion. Comparing "which callback ran" would not work — the
+    // `client` promise's own `.then` runs either way, whatever this function awaited.
+    let called = 0;
+    const started = Date.now();
+    await settleBullConnection({
+      client: new Promise(() => {}),
+      waitUntilReady: async () => {
+        called += 1;
+      },
+    });
+    expect(called).toBe(1);
+    expect(Date.now() - started).toBeLessThan(CONNECTION_SETTLE_TIMEOUT_MS);
+  });
+});

--- a/packages/runtime-redis/src/redis-connection.ts
+++ b/packages/runtime-redis/src/redis-connection.ts
@@ -62,13 +62,37 @@ export async function closeConnection(client: Redis): Promise<void> {
  * Wait for a BullMQ resource's connection to finish handshaking before it is closed.
  *
  * BullMQ owns the connection and opens it eagerly in the constructor, so we cannot make it lazy the
- * way the bus's own client is — but `client` resolves once that connection is up, which is enough to
- * turn the race into an ordered shutdown. Bounded and error-swallowing: an unreachable Redis must
- * make teardown slower, never hang it.
+ * way the bus's own client is — but it exposes a promise that resolves once that connection is up,
+ * which is enough to turn the race into an ordered shutdown. Bounded, error-swallowing, and
+ * indifferent to which BullMQ major is installed: an unreachable Redis, or an API that moved, must
+ * make teardown slower or duller, never fail it.
  */
-export async function settleBullConnection(resource: { client: Promise<unknown> }): Promise<void> {
+export async function settleBullConnection(resource: {
+  client?: Promise<unknown>;
+  waitUntilReady?: () => Promise<unknown>;
+}): Promise<void> {
+  // `client` is BullMQ 5's spelling and `waitUntilReady()` is BullMQ 6's, where the `client` getter
+  // is gone and reading it yields `undefined`. Probing for both keeps teardown correct across the
+  // boundary — and, more to the point, keeps a *shutdown* helper from being the thing that throws:
+  // this used to do `resource.client.then(...)` unconditionally, so on BullMQ 6 every stop ended
+  // with `Cannot read properties of undefined (reading 'then')` reported as an unclean shutdown.
+  // Neither present is a no-op, not an error: settling is an optimisation over closing, and the
+  // close that follows is what actually has to happen.
+  //
+  // Reading and calling are both inside the try for the same reason the whole helper is forgiving: a
+  // partly-constructed Queue or Worker can throw *synchronously* out of either (its `backend` or
+  // `blockingConnection` is not there yet), and an exception escaping here would skip the `close()`
+  // the caller runs next — which is the one thing teardown genuinely must do.
+  let settled: unknown;
+  try {
+    settled =
+      typeof resource.waitUntilReady === "function" ? resource.waitUntilReady() : resource.client;
+  } catch {
+    return;
+  }
+  if (settled == null) return;
   await Promise.race([
-    resource.client.then(
+    Promise.resolve(settled).then(
       () => undefined,
       () => undefined,
     ),

--- a/packages/storage-postgres/package.json
+++ b/packages/storage-postgres/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "@skein-js/core": "workspace:*",
-    "pg": ">=8.11.0"
+    "pg": "^8.11.0"
   },
   "peerDependencies": {
     "@langchain/langgraph-checkpoint-postgres": "^1.0.4"

--- a/packages/test-support/src/package-exports.test.ts
+++ b/packages/test-support/src/package-exports.test.ts
@@ -59,6 +59,35 @@ describe("publishable package manifests", () => {
     expect(libraryPackages.length).toBe(19);
   });
 
+  // Ranges we *install* have to name a major, because npm resolves them at install time and a
+  // caret is the only thing that stops the next major arriving in a fresh install untested. This is
+  // not hypothetical: `"bullmq": ">=5.0.0"` and `"ioredis": ">=5.4.0"` shipped, both majors were
+  // published, and every fresh install of `@skein-js/redis` got code the suite has never run
+  // against — surfacing as `Cannot read properties of undefined (reading 'then')` on every shutdown,
+  // because BullMQ 6 dropped the `client` getter the teardown helper read.
+  //
+  // `peerDependencies` are deliberately exempt: there the *host* chooses the version and a wide
+  // range is the point — an adapter that pinned `express` to one major would be the bug.
+  it.each(publishablePackages.map((pkg) => [pkg.manifest.name as string, pkg] as const))(
+    "%s pins a major for every dependency it installs",
+    (_name, pkg) => {
+      // An allowlist of shapes, not a denylist of one. `>=` is merely how this happened to be
+      // written; `*`, `>5.0.0`, `latest` and `5 || 6` all admit an untested major just as freely,
+      // and a guard that named only the spelling it had already seen would not have caught them.
+      const allowed = /^(?:workspace:\*|[~^]?\d+\.\d+\.\d+(?:-[\w.]+)?)$/;
+      const installed = {
+        ...((pkg.manifest.dependencies ?? {}) as Record<string, string>),
+        ...((pkg.manifest.optionalDependencies ?? {}) as Record<string, string>),
+      };
+      const unbounded = Object.entries(installed).filter(([, range]) => !allowed.test(range));
+
+      expect(
+        unbounded,
+        "use `^x.y.z` (or an exact version) for anything installed rather than brought by the host",
+      ).toEqual([]);
+    },
+  );
+
   it.each(libraryPackages.map((pkg) => [pkg.manifest.name as string, pkg] as const))(
     "%s resolves under both import and require",
     (_name, pkg) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -933,11 +933,11 @@ importers:
         specifier: workspace:*
         version: link:../core
       bullmq:
-        specifier: '>=5.0.0'
+        specifier: ^5.0.0
         version: 5.80.2
       ioredis:
-        specifier: '>=5.4.0'
-        version: 5.9.3
+        specifier: ^5.4.0
+        version: 5.10.1
     devDependencies:
       '@skein-js/test-support':
         specifier: workspace:*
@@ -1160,7 +1160,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       pg:
-        specifier: '>=8.11.0'
+        specifier: ^8.11.0
         version: 8.21.0
     devDependencies:
       '@skein-js/test-support':
@@ -2766,9 +2766,6 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
-
-  '@ioredis/commands@1.5.0':
-    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
   '@ioredis/commands@1.5.1':
     resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
@@ -6430,6 +6427,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -6979,10 +6977,6 @@ packages:
 
   ioredis@5.10.1:
     resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
-    engines: {node: '>=12.22.0'}
-
-  ioredis@5.9.3:
-    resolution: {integrity: sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==}
     engines: {node: '>=12.22.0'}
 
   ipaddr.js@1.9.1:
@@ -11346,8 +11340,6 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
-
-  '@ioredis/commands@1.5.0': {}
 
   '@ioredis/commands@1.5.1': {}
 
@@ -16270,20 +16262,6 @@ snapshots:
   ioredis@5.10.1:
     dependencies:
       '@ioredis/commands': 1.5.1
-      cluster-key-slot: 1.1.2
-      debug: 4.4.3(supports-color@7.2.0)
-      denque: 2.1.0
-      lodash.defaults: 4.2.0
-      lodash.isarguments: 3.1.0
-      redis-errors: 1.2.0
-      redis-parser: 3.0.0
-      standard-as-callback: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-
-  ioredis@5.9.3:
-    dependencies:
-      '@ioredis/commands': 1.5.0
       cluster-key-slot: 1.1.2
       debug: 4.4.3(supports-color@7.2.0)
       denque: 2.1.0


### PR DESCRIPTION
Found while extending the `scaffold-smoke` job in #42 — which installs the *published* packages, and
therefore hit exactly what a user hits. Every `skein start` shutdown ended with:

```
warn: Run queue did not close cleanly during shutdown
      error=Cannot read properties of undefined (reading 'then')
skein: shutdown did not complete cleanly: Cannot read properties of undefined (reading 'then')
```

## Root cause: an unbounded range in `dependencies`

`packages/runtime-redis/package.json` declared:

```json
"ioredis": ">=5.4.0",
"bullmq":  ">=5.0.0"
```

These are **`dependencies`**, not peer ranges. That distinction is the bug. A peer range is chosen by
the *host* and breadth is the point; a dependency range is resolved by **npm at install time**, so an
open upper bound means "whatever major is newest the day someone installs".

Both majors have shipped. The lockfile here pins bullmq **5.80.2** and ioredis **5.10.1**, so the
suite has only ever run those. A fresh install of `@skein-js/redis` today resolves bullmq **6.3.4**
and ioredis **6.0.0**.

BullMQ 6 dropped the `client` getter, and `settleBullConnection` read `resource.client.then(...)`
unconditionally. Verified directly against a real bullmq 6 install:

```
Queue.client  = undefined
Worker.client = undefined
settle worker: THREW: Cannot read properties of undefined (reading 'then')
```

## The fix

**1. Bound the ranges to the tested majors** — `^5.0.0` / `^5.4.0`. `pg` in
`@skein-js/storage-postgres` carried the identical latent bug (`>=8.11.0` would ship pg 9 the same
way, silently, on release day), so it is bounded too. Lockfile specifiers updated to match.

**2. Make `settleBullConnection` indifferent to the major.** It prefers `waitUntilReady()` — BullMQ
6's spelling, and on BullMQ 5 a *strict improvement*, since v5's `Worker` override additionally awaits
`blockingConnection.client`, which is created eagerly in the constructor and was previously left
unsettled. It falls back to `client`, and treats an unrecognised shape *or a synchronous throw* as a
no-op: settling is an optimisation over closing, and the `close()` that follows is the thing teardown
genuinely has to do, so this helper must never be what fails. Confirmed no-throw against real bullmq 6.

**3. A guard so it cannot recur** — in `package-exports.test.ts`, where the workspace-level manifest
assertions already live. Written as an **allowlist of shapes**, not a ban on `>=`: `*`, `latest`,
`>5.0.0` and `5 || 6` admit an untested major just as freely, and a guard naming only the spelling
already seen would not have caught them. Verified it rejects all five.
`peerDependencies` are exempt by design — an adapter pinning `express` to one major would be the bug.

## Scope

This does **not** add BullMQ 6 support. The surface used is small (`Queue`, `Worker`, `.add`,
`.close`), so it may be close to working — but claiming a major is supported without running against
it is precisely how this happened. Worth its own issue.

Note the `scaffold-smoke` shutdown warning will persist until this is released, since that job
installs the published `@skein-js/redis`, which still carries the open range.

## Verification

`nx test runtime-redis` (17, including the new `redis-connection.test.ts`), `nx test test-support`
(65), `nx test-integration runtime-redis` (22, Testcontainers), and the pre-commit gate across 25
projects — all green.