### PR TITLE
feat(docs): serve llms.txt and add a Copy-page control to every doc

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,8 @@ import { defineConfig } from "vitepress";
 import { withMermaid } from "vitepress-plugin-mermaid";
 import { tabsMarkdownPlugin } from "vitepress-plugin-tabs";
 
+import { llmAssetsDevPlugin, writeLlmAssets } from "./llm-assets";
+
 // The docs site. `docs/` is VitePress's default srcDir, so every markdown file here stays exactly
 // where README.md, llms.txt and scripts/generate-llms-full.mjs already point at it — the site is
 // configuration layered over the repo's docs, not a copy of them.
@@ -150,7 +152,14 @@ export default withMermaid(
     // makes esbuild pre-bundle both and emit the ESM wrapper the dev server needs.
     vite: {
       optimizeDeps: { include: ["mermaid", "dayjs"] },
+      // Serves `/llms.txt`, `/llms-full.txt` and every page's `.md` twin over the dev server, so the
+      // Copy-page control is exercised locally rather than first on Pages. See llm-assets.ts.
+      plugins: [llmAssetsDevPlugin()],
     },
+
+    // The build half of the same thing: copy the two curated bundles out of the repo root and emit a
+    // raw `.md` beside every page. Runs after the SSG output exists, so it only ever adds files.
+    buildEnd: writeLlmAssets,
 
     // `:::tabs` containers, used on the landing page so the three on-ramps are a choice rather than
     // three stacked walls of content. Client half is registered in theme/index.ts.

--- a/docs/.vitepress/llm-assets.ts
+++ b/docs/.vitepress/llm-assets.ts
@@ -1,0 +1,161 @@
+import { existsSync } from "node:fs";
+import { copyFile, mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+import type { Plugin } from "vite";
+import type { SiteConfig } from "vitepress";
+
+/**
+ * Serving the site's LLM-facing surface: `/llms.txt`, `/llms-full.txt`, and a raw `.md` twin of
+ * every page.
+ *
+ * Why this exists at all: the two bundles are already generated (`pnpm docs:llms`) and already
+ * curated by hand, but they live at the **repo root** — so before this, nothing served them. An
+ * agent pointed at the docs site got a 404 on the one path the convention says to try first, and the
+ * only working copy was a raw.githubusercontent.com URL. llmstxt.org puts `llms.txt` at the site
+ * root; that is the whole point of the filename.
+ *
+ * Why the root files are read rather than duplicated into `docs/public/`: two copies of one file is
+ * the defect shape this repo pays for most. `llms.txt` is hand-written and `llms-full.txt` is
+ * concatenated in a deliberate order ("Order matters — it's the narrative", per its generator), so
+ * they have exactly one author each. This module copies them at build time and streams them in dev;
+ * `pnpm docs:llms` stays the only thing that writes them.
+ *
+ * Why per-page `.md` twins are emitted rather than linking to GitHub: a deployed site and `main` are
+ * not the same content, so a "view as markdown" link to raw GitHub shows a reader a different page
+ * than the one they are on. Same-origin twins also need no network and no CORS, and they give an
+ * agent a URL per page instead of one 636 KB bundle.
+ */
+
+/** The two bundles, at the repo root, named by the convention that makes them findable. */
+const BUNDLES = ["llms.txt", "llms-full.txt"] as const;
+
+/**
+ * A page's markdown twin is served at its own route plus `.md` — `/why` → `/why.md`.
+ *
+ * That falls out of VitePress's own vocabulary rather than needing a mapping table: `relativePath`
+ * *is* the served path (post-`rewrites`), so writing each page to `outDir/<relativePath>` puts the
+ * twin exactly where the client computes it should be. `useData().page.relativePath` is the same
+ * string on the client, which is why CopyPage.vue needs no knowledge of any of this.
+ */
+const twinPath = (servedPath: string) => servedPath;
+
+/**
+ * Frontmatter is stripped. It is site configuration — `layout: home`, a `description` override — and
+ * never prose, so to a reader it is noise and to a model it is noise that looks like content.
+ * `generate-llms-full.mjs` strips it from `docs/index.md` for the same reason; this applies the rule
+ * to every page instead of the one that happened to need it.
+ */
+const stripFrontmatter = (markdown: string) => markdown.replace(/^---\r?\n.*?\r?\n---\r?\n/s, "");
+
+/**
+ * Every page on the site, as `{ sourceFile, servedPath }`.
+ *
+ * `siteConfig.pages` is the post-`srcExclude` file list and `siteConfig.rewrites.map` is the
+ * source→served mapping, both already computed by VitePress — so the three contributor docs excluded
+ * from the site get no twin, and `proposals/README.md` is served as `proposals/index.md`, without
+ * this file restating either rule.
+ */
+const pagesOf = (siteConfig: SiteConfig) =>
+  siteConfig.pages.map((page) => ({
+    sourceFile: page,
+    servedPath: siteConfig.rewrites.map[page] ?? page,
+  }));
+
+/**
+ * Write the bundles and the twins into the built site.
+ *
+ * Called from `buildEnd`, which runs after the SSG output exists, so this only adds files and can
+ * never race the pages themselves.
+ */
+export const writeLlmAssets = async (siteConfig: SiteConfig) => {
+  const repoRoot = resolve(siteConfig.srcDir, "..");
+
+  await Promise.all(
+    BUNDLES.map(async (name) => {
+      const source = join(repoRoot, name);
+      // Absent rather than fatal: `llms-full.txt` is generated, so a fresh clone that has not run
+      // `pnpm docs:llms` yet would otherwise fail the build — and the docs build is what gates the
+      // Pages deploy. A missing bundle costs one dropdown entry a 404; it must not cost the deploy.
+      if (!existsSync(source)) {
+        console.warn(`[llm-assets] ${name} not found at the repo root — run \`pnpm docs:llms\`.`);
+        return;
+      }
+      await copyFile(source, join(siteConfig.outDir, name));
+    }),
+  );
+
+  await Promise.all(
+    pagesOf(siteConfig).map(async ({ sourceFile, servedPath }) => {
+      const markdown = await readFile(join(siteConfig.srcDir, sourceFile), "utf8");
+      const target = join(siteConfig.outDir, twinPath(servedPath));
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, stripFrontmatter(markdown));
+    }),
+  );
+};
+
+/**
+ * The same two things, over the dev server.
+ *
+ * Without this the dropdown works in production and 404s under `pnpm docs:dev`, which is the shape
+ * of bug nobody finds until it is deployed. Reads on request rather than copying, so editing a doc
+ * changes its twin with no restart.
+ */
+export const llmAssetsDevPlugin = (): Plugin => ({
+  name: "skein:llm-assets",
+  // `pre`, so the request is answered before Vite's own static and transform middlewares try to
+  // resolve a `.md` URL as a module graph entry.
+  enforce: "pre",
+  configureServer(server) {
+    // VitePress attaches its resolved config to the Vite config (`vitepress: siteConfig`, set in its
+    // own `config()` hook, which has run by the time `configureServer` does). Vite's own
+    // `ResolvedConfig` type does not declare the field, hence the cast.
+    const siteConfig = (server.config as unknown as { vitepress?: SiteConfig }).vitepress;
+    if (!siteConfig) return;
+
+    const repoRoot = resolve(siteConfig.srcDir, "..");
+    // Served twin path → file on disk. `siteConfig.rewrites.inv` would answer the second half, but
+    // this map answers both halves at once: a miss means "not a page on this site", which is what
+    // keeps the three `srcExclude`d contributor docs from being readable here.
+    const sourceOf = new Map(
+      pagesOf(siteConfig).map(({ sourceFile, servedPath }) => [twinPath(servedPath), sourceFile]),
+    );
+    const base = server.config.base;
+
+    server.middlewares.use((req, res, next) => {
+      if (!req.url) return next();
+
+      // A query string means Vite, not a reader. VitePress loads every page's *module* from that
+      // page's markdown — `/why.md?import&t=…`, because a `.md` file here compiles to a Vue SFC — so
+      // answering those with `text/plain` breaks strict MIME checking and the page renders as a 404.
+      // Cost one round of that before the guard existed; production has no module graph, so the
+      // collision is dev-only and invisible to a build.
+      const [url, query] = req.url.split("?");
+      if (query !== undefined) return next();
+
+      // Vite strips `base` for some middleware positions and not others, so accept both spellings
+      // rather than depending on where in the chain this lands.
+      const path = decodeURIComponent(
+        url.startsWith(base) ? url.slice(base.length) : url.replace(/^\//, ""),
+      );
+
+      const bundle = BUNDLES.find((name) => name === path);
+      const source = bundle ? join(repoRoot, bundle) : undefined;
+      const page = sourceOf.get(path);
+
+      if (!source && !page) return next();
+
+      const file = source ?? join(siteConfig.srcDir, page!);
+      if (!existsSync(file)) return next();
+
+      void readFile(file, "utf8").then((text) => {
+        // `text/plain` so a browser renders it instead of downloading it — "View as Markdown" is
+        // meant to be read in a tab. `charset` is explicit because these files carry em dashes and
+        // arrows throughout, and a sniffed charset mangles them.
+        res.setHeader("content-type", "text/plain; charset=utf-8");
+        res.end(page ? stripFrontmatter(text) : text);
+      });
+    });
+  },
+});

--- a/docs/.vitepress/theme/Layout.vue
+++ b/docs/.vitepress/theme/Layout.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+// A wrapper around the default layout rather than a fork of it — the one slot this site fills.
+// `doc-before` is a doc-layout slot, so the button appears on every prose page and on none of the
+// pages that have no prose: the `layout: home` landing page and 404 never render it, with no
+// frontmatter check here to keep in sync.
+import DefaultTheme from "vitepress/theme-without-fonts";
+
+import CopyPage from "./components/CopyPage.vue";
+
+const { Layout } = DefaultTheme;
+</script>
+
+<template>
+  <Layout>
+    <template #doc-before>
+      <CopyPage />
+    </template>
+  </Layout>
+</template>

--- a/docs/.vitepress/theme/components/CopyPage.vue
+++ b/docs/.vitepress/theme/components/CopyPage.vue
@@ -1,0 +1,507 @@
+<script setup lang="ts">
+// The LLM-facing affordance on every doc page: hand this page to a model, or point one at the whole
+// site. The menu is deliberately short — three things a reader can do today, and no MCP entry until
+// `/mcp` exists (roadmap), because an entry that installs a server which answers nothing is worse
+// than no entry.
+//
+// Nothing here knows where the files come from. The markdown twin is this page's own route plus
+// `.md`, which is what `docs/.vitepress/llm-assets.ts` writes on build and serves in dev — one rule,
+// stated once, so the client and the server cannot disagree about a path.
+import { computed, nextTick, onBeforeUnmount, ref, useTemplateRef } from "vue";
+import { useData, withBase } from "vitepress";
+
+const { page } = useData();
+
+/**
+ * `relativePath` is the *served* path (post-`rewrites`), so appending nothing but a leading slash
+ * gives the twin's URL by construction.
+ *
+ * The leading slash is load-bearing, not tidiness: `withBase` is documented as appending the base to
+ * "internal (non-relative) urls" and **returns anything not starting with `/` unchanged**. Without
+ * it these stay relative and resolve against the current directory — which is right by accident at
+ * the top level (`/why` + `why.md` → `/why.md`) and wrong one level down, where `/recipes/memory` +
+ * `recipes/memory.md` becomes `/recipes/recipes/memory.md`. That URL answers **200 with the SPA
+ * HTML shell** rather than 404, so a copy would silently put HTML on the clipboard and no
+ * `response.ok` check would notice.
+ */
+const markdownUrl = computed(() => withBase(`/${page.value.relativePath}`));
+const llmsUrl = withBase("/llms.txt");
+const llmsFullUrl = withBase("/llms-full.txt");
+
+const open = ref(false);
+/** `copied` and `failed` are shown on the button itself — a menu that closes with no feedback reads as a no-op. */
+const status = ref<"idle" | "copied" | "failed">("idle");
+const root = useTemplateRef<HTMLElement>("root");
+const toggle = useTemplateRef<HTMLButtonElement>("toggle");
+
+let resetTimer: ReturnType<typeof setTimeout> | undefined;
+const report = (outcome: "copied" | "failed") => {
+  status.value = outcome;
+  clearTimeout(resetTimer);
+  resetTimer = setTimeout(() => (status.value = "idle"), 2000);
+};
+
+const write = async (text: string) => {
+  try {
+    // Secure-context only, which localhost satisfies — so this works under `pnpm docs:dev` as well
+    // as on Pages, and there is no separate dev path to keep working.
+    await navigator.clipboard.writeText(text);
+    report("copied");
+  } catch {
+    report("failed");
+  }
+};
+
+const copyMarkdown = async () => {
+  close();
+  try {
+    const response = await fetch(markdownUrl.value);
+    if (!response.ok) throw new Error(String(response.status));
+    await write(await response.text());
+  } catch {
+    report("failed");
+  }
+};
+
+const copyHtml = async () => {
+  close();
+  // `.vp-doc` is the rendered article and nothing else: this component renders in the `doc-before`
+  // slot, which VitePress puts *outside* `.vp-doc`, so the copied HTML never contains this button.
+  const article = document.querySelector(".vp-doc");
+  if (!article) return report("failed");
+  await write(article.innerHTML);
+};
+
+const close = () => {
+  open.value = false;
+};
+
+const onDocumentPointerDown = (event: PointerEvent) => {
+  if (!root.value?.contains(event.target as Node)) close();
+};
+
+const onToggle = () => {
+  open.value = !open.value;
+  if (open.value) {
+    document.addEventListener("pointerdown", onDocumentPointerDown);
+    // `role="menu"` is a promise that arrow keys work and that opening lands focus inside. Making the
+    // claim without the behaviour is worse than not making it — a screen reader announces a menu and
+    // then the keys it just told the reader to use do nothing.
+    void nextTick(() => items()[0]?.focus());
+  } else {
+    document.removeEventListener("pointerdown", onDocumentPointerDown);
+  }
+};
+
+/** The focusable menu items, in DOM order — read live, so adding an entry needs nothing here. */
+const items = () => [...(root.value?.querySelectorAll<HTMLElement>(".copy-page-item") ?? [])];
+
+const onArrow = (step: 1 | -1) => {
+  if (!open.value) return;
+  const all = items();
+  if (all.length === 0) return;
+  const from = all.indexOf(document.activeElement as HTMLElement);
+  // Wraps, and an ArrowUp with focus still on the toggle enters at the end rather than doing nothing.
+  const next =
+    from === -1 ? (step === 1 ? 0 : all.length - 1) : (from + step + all.length) % all.length;
+  all[next]?.focus();
+};
+
+const onEscape = () => {
+  if (!open.value) return;
+  close();
+  // Focus goes back to what opened the menu, or a keyboard reader is dropped at the top of the page.
+  toggle.value?.focus();
+};
+
+onBeforeUnmount(() => {
+  clearTimeout(resetTimer);
+  document.removeEventListener("pointerdown", onDocumentPointerDown);
+});
+</script>
+
+<template>
+  <div
+    ref="root"
+    class="copy-page"
+    @keydown.esc="onEscape"
+    @keydown.down.prevent="onArrow(1)"
+    @keydown.up.prevent="onArrow(-1)"
+  >
+    <div class="copy-page-group">
+      <!-- The primary action is the one the menu's first item names, so the common case is one click.
+           No `aria-label`: it would override the visible text, and the visible text is what changes to
+           "Copied" — labelling this would make the one piece of feedback the control has unannounced. -->
+      <button class="copy-page-action" type="button" @click="copyMarkdown">
+        <svg
+          v-if="status === 'copied'"
+          class="copy-page-icon"
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+        >
+          <path
+            d="M3 8.5l3.2 3.2L13 5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.6"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+        <svg v-else class="copy-page-icon" viewBox="0 0 16 16" aria-hidden="true">
+          <rect
+            x="5.25"
+            y="5.25"
+            width="8"
+            height="8"
+            rx="1.75"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+          />
+          <path
+            d="M10.75 3.4A1.9 1.9 0 0 0 9 2.25H4.5A2.25 2.25 0 0 0 2.25 4.5V9c0 .8.49 1.48 1.19 1.77"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.4"
+            stroke-linecap="round"
+          />
+        </svg>
+        <span>{{
+          status === "copied" ? "Copied" : status === "failed" ? "Copy failed" : "Copy page"
+        }}</span>
+      </button>
+
+      <button
+        ref="toggle"
+        class="copy-page-chevron"
+        type="button"
+        aria-haspopup="menu"
+        :aria-expanded="open"
+        aria-label="More ways to read this page"
+        @click="onToggle"
+      >
+        <svg class="copy-page-icon" viewBox="0 0 16 16" aria-hidden="true">
+          <path
+            :d="open ? 'M4.5 9.75L8 6.25l3.5 3.5' : 'M4.5 6.25L8 9.75l3.5-3.5'"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+    </div>
+
+    <div v-show="open" class="copy-page-menu" role="menu">
+      <button class="copy-page-item" type="button" role="menuitem" @click="copyMarkdown">
+        <span class="copy-page-item-icon" aria-hidden="true">
+          <svg viewBox="0 0 16 16">
+            <rect
+              x="5.25"
+              y="5.25"
+              width="8"
+              height="8"
+              rx="1.75"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+            />
+            <path
+              d="M10.75 3.4A1.9 1.9 0 0 0 9 2.25H4.5A2.25 2.25 0 0 0 2.25 4.5V9c0 .8.49 1.48 1.19 1.77"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+              stroke-linecap="round"
+            />
+          </svg>
+        </span>
+        <span class="copy-page-item-text">
+          <span class="copy-page-item-title">Copy page</span>
+          <span class="copy-page-item-hint">Copy this page as Markdown, for an LLM</span>
+        </span>
+      </button>
+
+      <a
+        class="copy-page-item"
+        role="menuitem"
+        :href="markdownUrl"
+        target="_blank"
+        rel="noreferrer"
+        @click="close"
+      >
+        <span class="copy-page-item-icon" aria-hidden="true">
+          <svg viewBox="0 0 16 16">
+            <rect
+              x="1.75"
+              y="3.75"
+              width="12.5"
+              height="8.5"
+              rx="1.75"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+            />
+            <path
+              d="M4.4 10.1V5.9l1.9 2.3 1.9-2.3v4.2M10.4 5.9v4.2M10.4 10.1l1.5-1.7M10.4 10.1L8.9 8.4"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+        <span class="copy-page-item-text">
+          <span class="copy-page-item-title"
+            >View as Markdown <span class="copy-page-out">↗</span></span
+          >
+          <span class="copy-page-item-hint">Open this page as plain text</span>
+        </span>
+      </a>
+
+      <button class="copy-page-item" type="button" role="menuitem" @click="copyHtml">
+        <span class="copy-page-item-icon" aria-hidden="true">
+          <svg viewBox="0 0 16 16">
+            <path
+              d="M6.1 4.4L2.6 8l3.5 3.6M9.9 4.4L13.4 8l-3.5 3.6"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+        <span class="copy-page-item-text">
+          <span class="copy-page-item-title">Copy as HTML</span>
+          <span class="copy-page-item-hint">Copy the rendered page markup</span>
+        </span>
+      </button>
+
+      <div class="copy-page-divider" role="separator"></div>
+
+      <a
+        class="copy-page-item"
+        role="menuitem"
+        :href="llmsUrl"
+        target="_blank"
+        rel="noreferrer"
+        @click="close"
+      >
+        <span class="copy-page-item-icon" aria-hidden="true">
+          <svg viewBox="0 0 16 16">
+            <path
+              d="M3.75 2.25h5.4l3.1 3.1v8.4a.9.9 0 0 1-.9.9h-7.6a.9.9 0 0 1-.9-.9V3.15a.9.9 0 0 1 .9-.9z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M9 2.4v3.1h3.1M5.6 8.6h4.8M5.6 11h3.2"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+            />
+          </svg>
+        </span>
+        <span class="copy-page-item-text">
+          <span class="copy-page-item-title">llms.txt <span class="copy-page-out">↗</span></span>
+          <span class="copy-page-item-hint">The index of every doc, for an agent</span>
+        </span>
+      </a>
+
+      <a
+        class="copy-page-item"
+        role="menuitem"
+        :href="llmsFullUrl"
+        target="_blank"
+        rel="noreferrer"
+        @click="close"
+      >
+        <span class="copy-page-item-icon" aria-hidden="true">
+          <svg viewBox="0 0 16 16">
+            <path
+              d="M5.25 1.75h4.4l2.6 2.6v7.4a.9.9 0 0 1-.9.9h-6.1a.9.9 0 0 1-.9-.9V2.65a.9.9 0 0 1 .9-.9z"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.4"
+              stroke-linejoin="round"
+            />
+            <path
+              d="M3.4 4.4v9.05a.9.9 0 0 0 .9.9h6.1"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.3"
+              stroke-linecap="round"
+            />
+          </svg>
+        </span>
+        <span class="copy-page-item-text">
+          <span class="copy-page-item-title"
+            >llms-full.txt <span class="copy-page-out">↗</span></span
+          >
+          <span class="copy-page-item-hint">Every doc as one file, in reading order</span>
+        </span>
+      </a>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* Floated so the page's own H1 sets beside it, which is where a reader looks for a page-level
+   action. `doc-before` is a sibling of <main>, so the float intrudes into it and the heading's line
+   boxes shorten around this — no absolute positioning, nothing to keep in sync with the theme. */
+.copy-page {
+  position: relative;
+  float: right;
+  margin: 0 0 12px 20px;
+  /* Above the heading and the sticky aside, or the open menu renders behind the outline. */
+  z-index: 20;
+}
+
+/* Narrow screens have no room beside the title, and a float there would squeeze the H1 into a
+   two-word column. Unfloated, it sits above the title, right-aligned. */
+@media (max-width: 720px) {
+  .copy-page {
+    float: none;
+    display: flex;
+    justify-content: flex-end;
+    margin: 0 0 16px;
+  }
+}
+
+.copy-page-group {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 8px;
+  background-color: var(--vp-c-bg);
+  overflow: hidden;
+}
+
+.copy-page-action,
+.copy-page-chevron {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 0 10px;
+  height: 32px;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+  color: var(--vp-c-text-1);
+  background-color: transparent;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
+  white-space: nowrap;
+}
+
+.copy-page-action:hover,
+.copy-page-chevron:hover {
+  background-color: var(--vp-c-bg-soft);
+}
+
+/* The hairline between the two halves — the same 1px the rest of the surface separates with. */
+.copy-page-chevron {
+  padding: 0 6px;
+  border-left: 1px solid var(--vp-c-border);
+  color: var(--vp-c-text-2);
+}
+
+.copy-page-icon {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.copy-page-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 310px;
+  /* The menu is right-anchored to the button, which sits at the right gutter — so on a 320px screen
+     a fixed width hangs 14px off the left edge and is clipped, with no scrollbar to reveal it. */
+  max-width: calc(100vw - 32px);
+  padding: 6px;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 10px;
+  background-color: var(--vp-c-bg-elv);
+  box-shadow: var(--vp-shadow-3);
+}
+
+.copy-page-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 7px 8px;
+  border-radius: 7px;
+  text-align: left;
+  color: var(--vp-c-text-1);
+  transition: background-color 0.15s;
+}
+
+.copy-page-item:hover {
+  background-color: var(--vp-c-bg-soft);
+}
+
+/* Links inside the menu are menu items, not prose — the theme's underline and accent colour would
+   make five of them read as a paragraph of links. */
+.copy-page-item,
+.copy-page-item:hover {
+  text-decoration: none;
+}
+
+.copy-page-item-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 6px;
+  color: var(--vp-c-text-2);
+}
+
+.copy-page-item-icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.copy-page-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.copy-page-item-title {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.copy-page-item-hint {
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--vp-c-text-3);
+}
+
+.copy-page-out {
+  font-size: 11px;
+  color: var(--vp-c-text-3);
+}
+
+.copy-page-divider {
+  height: 1px;
+  margin: 5px 8px;
+  background-color: var(--vp-c-divider);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -7,13 +7,17 @@ import DefaultTheme from "vitepress/theme-without-fonts";
 // as "pick yours" rather than as three walls of content stacked on each other. This is the plugin
 // maintained alongside VitePress itself rather than a hand-rolled component — golden rule 1.
 import { enhanceAppWithTabs } from "vitepress-plugin-tabs/client";
+
+import Layout from "./Layout.vue";
 import "./style.css";
 
-// The default theme with the console's tokens layered on top — see style.css. Nothing here extends
-// the layout; if the site ever needs slots (`home-hero-image`, `doc-after`), add a Layout wrapper
-// rather than forking the theme.
+// The default theme with the console's tokens layered on top — see style.css. `Layout` is a wrapper
+// around the default one that fills a single slot (`doc-before`, for the Copy-page control), which is
+// the documented way to add a slot without forking the theme; add further slots there rather than
+// here.
 export default {
   extends: DefaultTheme,
+  Layout,
   enhanceApp({ app }) {
     enhanceAppWithTabs(app);
   },


### PR DESCRIPTION
`llms.txt` and `llms-full.txt` exist only at the repo root today, so the site never served them — `/llms.txt` 404s for an agent pointed at the docs. This serves both at the site root (read from the root files, not copied, so `pnpm docs:llms` stays the only writer), gives every page a raw `.md` twin at its own route, and adds a dropdown to reach them.

Same pattern as the **Copy page** control on Mintlify-hosted docs — e.g. [docs.langchain.com](https://docs.langchain.com/oss/javascript/langchain/overview):

<!-- screenshot of the reference UI -->

Menu: Copy page (Markdown) · View as Markdown · Copy as HTML · llms.txt · llms-full.txt. No MCP entry until `/mcp` lands (#11).

**Not** using `vitepress-plugin-llms`: its main job is *generating* these files, which would clobber the hand-written index and the curated order in `generate-llms-full.mjs` ("Order matters — it's the narrative"). Happy to switch if you'd rather take the dependency.

Checked: `nx format:check`, `nx lint docs`, `vitepress build` (52 twins + both bundles; the three `srcExclude`d contributor docs correctly get none), plus in-browser light/dark, keyboard nav, and the built output via `vitepress preview`.

One caveat: Pages serves `.md` as `text/markdown`, which some browsers download rather than display — so "View as Markdown" may save a file. Kept `.md` because that is what agents look for.

> 🤖 Written by Claude Opus 5 (Claude Code), reviewed by me before opening.
